### PR TITLE
Added sc as first parameter to GridSearchCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ from spark_sklearn import GridSearchCV
 iris = datasets.load_iris()
 parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
 svr = svm.SVC()
-clf = GridSearchCV(svr, parameters)
+clf = GridSearchCV(sc, svr, parameters)
 clf.fit(iris.data, iris.target)
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -50,7 +50,7 @@ from spark_sklearn import GridSearchCV
 iris = datasets.load_iris()
 parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
 svr = svm.SVC()
-clf = GridSearchCV(svr, parameters)
+clf = GridSearchCV(sc, svr, parameters)
 clf.fit(iris.data, iris.target)
 ```
 


### PR DESCRIPTION
It looks like the readme is missing the spark context as the first arg.