### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
 cache:
   directories:
     - $HOME/.cache/spark-versions

--- a/python/spark_sklearn/__init__.py
+++ b/python/spark_sklearn/__init__.py
@@ -1,8 +1,8 @@
 from scipy.sparse import csr_matrix
 
-from converter import Converter
-from grid_search import GridSearchCV
-from udt import CSRVectorUDT
+from spark_sklearn.converter import Converter
+from spark_sklearn.grid_search import GridSearchCV
+from spark_sklearn.udt import CSRVectorUDT
 
 __all__ = ['Converter', 'CSRVectorUDT', 'GridSearchCV']
 

--- a/python/spark_sklearn/converter.py
+++ b/python/spark_sklearn/converter.py
@@ -16,8 +16,8 @@ from pyspark.ml.regression import LinearRegressionModel
 from pyspark.mllib.linalg import DenseVector, SparseVector, Vectors, VectorUDT
 from pyspark.sql.functions import udf
 
-from udt import CSRVectorUDT
-from util import _new_java_obj, _randomUID
+from spark_sklearn.udt import CSRVectorUDT
+from spark_sklearn.util import _new_java_obj, _randomUID
 
 
 # ClassNames contains 2 corresponding fields:

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -207,7 +207,7 @@ class GridSearchCV(BaseSearchCV):
                       for (train, test) in cv]
         # Because the original python code expects a certain order for the elements, we need to
         # respect it.
-        indexed_param_grid = zip(range(len(param_grid)), param_grid)
+        indexed_param_grid = list(zip(range(len(param_grid)), param_grid))
         par_param_grid = self.sc.parallelize(indexed_param_grid, len(indexed_param_grid))
         X_bc = self.sc.broadcast(X)
         y_bc = self.sc.broadcast(y)


### PR DESCRIPTION
Add Python 3 compatibility:

- use absolute imports inside spark-sklearn
- convert `zip` output to list to be able to use `len`