### PR TITLE
Upgrades the Spark dep to 2.0 and changes the tests analogously.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
     - $HOME/.cache/spark-versions
 env:
   matrix:
-    - SPARK_VERSION="2.0.0-preview" SPARK_BUILD="spark-2.0.0-preview-bin-hadoop2.6" SPARK_BUILD_URL="http://apache.claz.org/spark/spark-2.0.0-preview/spark-2.0.0-preview-bin-hadoop2.6.tgz"
+    # TODO: remove snapshot dependency after 2.0.0 release
+    - SPARK_VERSION="2.0.0-SNAPSHOT" SPARK_BUILD="spark-2.0.0-SNAPSHOT-bin-hadoop2.6" SPARK_BUILD_URL="http://people.apache.org/~pwendell/spark-nightly/spark-branch-2.0-bin/latest/spark-2.0.0-SNAPSHOT-bin-hadoop2.6.tgz"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.cache/spark-versions
 env:
   matrix:
-    - SPARK_VERSION="2.0.0-preview" SPARK_BUILD="spark-2.0.0-preview" SPARK_BUILD_URL="http://apache.claz.org/spark/spark-2.0.0-preview/spark-2.0.0-preview.tgz"
+    - SPARK_VERSION="2.0.0-preview" SPARK_BUILD="spark-2.0.0-preview-bin-hadoop2.6" SPARK_BUILD_URL="http://apache.claz.org/spark/spark-2.0.0-preview/spark-2.0.0-preview-bin-hadoop2.6.tgz"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ cache:
     - $HOME/.cache/spark-versions
 env:
   matrix:
-    - SPARK_VERSION=1.6.0 SPARK_BUILD="spark-1.6.0-bin-hadoop2.6" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-1.6.0-bin-hadoop2.6.tgz"
-    - SPARK_VERSION=1.5.2 SPARK_BUILD="spark-1.5.2-bin-hadoop2.6" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-1.5.2-bin-hadoop2.6.tgz"
+    - SPARK_VERSION="2.0.0-preview" SPARK_BUILD="spark-2.0.0-preview" SPARK_BUILD_URL="http://apache.claz.org/spark/spark-2.0.0-preview/spark-2.0.0-preview.tgz"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 
 This package has the following requirements:
  - a recent release of scikit-learn. Release 0.17 has been tested, older versions may work too.
- - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
+ - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details. NOTICE: currently, this package uses the nightly 2.0.0 snapshot, available [here](http://people.apache.org/~pwendell/spark-nightly/spark-branch-2.0-bin/latest/) (TODO: remove reference after 2.0.0 release).
  - [nose](https://nose.readthedocs.org) (testing dependency only)
  - Pandas, if using the Pandas integration. Pandas==0.18 has been tested.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 
 This package has the following requirements:
  - a recent release of scikit-learn. Release 0.17 has been tested, older versions may work too.
- - Spark >= 1.5. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
+ - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)
  - Pandas, if using the Pandas integration. Pandas==0.18 has been tested.
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 
 ## Installation
 
-This package has the following requirements:
- - a recent release of scikit-learn. Release 0.17 has been tested, older versions may work too.
- - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details. NOTICE: currently, this package uses the nightly 2.0.0 snapshot, available [here](http://people.apache.org/~pwendell/spark-nightly/spark-branch-2.0-bin/latest/) (TODO: remove reference after 2.0.0 release).
- - [nose](https://nose.readthedocs.org) (testing dependency only)
- - Pandas, if using the Pandas integration. Pandas==0.18 has been tested.
-
 This package is available on PYPI:
 
 	pip install spark-sklearn
 
 This project is also available as as [Spark package](http://spark-packages.org/package/databricks/spark-sklearn).
+
+The developer version has the following requirements:
+ - a recent release of scikit-learn. Release 0.17 has been tested, older versions may work too.
+ - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details. NOTICE: currently, this package uses the nightly 2.0.0 snapshot, available [here](http://people.apache.org/~pwendell/spark-nightly/spark-branch-2.0-bin/latest/) (TODO: remove reference after 2.0.0 release).
+ - [nose](https://nose.readthedocs.org) (testing dependency only)
+ - Pandas, if using the Pandas integration or testing. Pandas==0.18 has been tested.
 
 If you want to use a developer version, you just need to make sure the `python/` subdirectory is in the `PYTHONPATH` when launching the pyspark interpreter:
 

--- a/bin/download_travis_dependencies.sh
+++ b/bin/download_travis_dependencies.sh
@@ -3,12 +3,15 @@ echo "Spark version = $SPARK_VERSION"
 echo "Spark build = $SPARK_BUILD"
 echo "Spark build URL = $SPARK_BUILD_URL"
 mkdir -p $HOME/.cache/spark-versions
-filename="$HOME/.cache/spark-versions/$SPARK_BUILD.tgz"
-if ! [ -f $filename ]; then
-	echo "Downloading file..."
-	echo `which curl`
-	curl "$SPARK_BUILD_URL" > $filename
-	echo "Content of directory:"
-	ls -la $HOME/.cache/spark-versions/*
-	tar xvf $filename --directory $HOME/.cache/spark-versions > /dev/null
+tarfilename="$HOME/.cache/spark-versions/$SPARK_BUILD.tgz"
+dirname="$HOME/.cache/spark-versions/$SPARK_BUILD"
+if ! [ -d $dirname ]; then
+    echo "Missing $dirname, downloading archive"
+    echo `which curl`
+    curl "$SPARK_BUILD_URL" > $tarfilename
+    tar xvf $tarfilename --directory $HOME/.cache/spark-versions > /dev/null
+    echo "Content of directory:"
+    ls -la $HOME/.cache/spark-versions/
+else
+    echo "Skipping download - found spark dir $dirname"
 fi

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 
 scalaVersion := "2.10.4"
 
-sparkVersion := "1.6.0-SNAPSHOT"
+sparkVersion := "2.0.0-SNAPSHOT"
 
 spName := "databricks/spark-sklearn"
 
@@ -13,9 +13,11 @@ version := "0.0.1-SNAPSHOT"
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-
 // Add Spark components this package depends on, e.g, "mllib", ....
 sparkComponents ++= Seq("mllib")
+
+// TODO: remove after Spark 2.0.0 is released:
+resolvers += "apache-snapshots" at "https://repository.apache.org/snapshots/"
 
 // uncomment and change the value below to change the directory where your zip artifact will be created
 // spDistDirectory := target.value

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 // Add Spark components this package depends on, e.g, "mllib", ....
 sparkComponents ++= Seq("mllib")
 
-// TODO: remove after Spark 2.0.0 is released:
+// TODO: remove after Spark 2.0.0 release:
 resolvers += "apache-snapshots" at "https://repository.apache.org/snapshots/"
 
 // uncomment and change the value below to change the directory where your zip artifact will be created

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -31,4 +31,4 @@ if [ "$#" = 0 ]; then
 else
     ARGS="$@"
 fi
-exec nosetests -v "$ARGS" -w $DIR
+exec nosetests -v $ARGS -w $DIR

--- a/python/spark_sklearn/converter.py
+++ b/python/spark_sklearn/converter.py
@@ -13,7 +13,7 @@ from sklearn.linear_model import LinearRegression as SKL_LinearRegression
 
 from pyspark.ml.classification import LogisticRegressionModel
 from pyspark.ml.regression import LinearRegressionModel
-from pyspark.mllib.linalg import DenseVector, SparseVector, Vectors, VectorUDT
+from pyspark.ml.linalg import DenseVector, SparseVector, Vectors, VectorUDT
 from pyspark.sql.functions import udf
 
 from spark_sklearn.udt import CSRVectorUDT
@@ -119,7 +119,7 @@ class Converter(object):
         py_cls = type(model)
         skl_cls = self._spark2skl_classes[py_cls]
         intercept = model.intercept
-        weights = model.weights
+        weights = model.coefficients
         skl = skl_cls()
         skl.intercept_ = np.float64(intercept)
         skl.coef_ = weights.toArray()

--- a/python/spark_sklearn/converter_test.py
+++ b/python/spark_sklearn/converter_test.py
@@ -2,7 +2,7 @@ from scipy.sparse import csr_matrix
 from sklearn.linear_model import LogisticRegression as SKL_LogisticRegression
 from sklearn.linear_model import LinearRegression as SKL_LinearRegression
 
-from pyspark.mllib.linalg import Vectors
+from pyspark.ml.linalg import Vectors
 from pyspark.ml.regression import LinearRegression, LinearRegressionModel
 from pyspark.ml.classification import LogisticRegression, LogisticRegressionModel
 
@@ -20,7 +20,7 @@ class ConverterTests(MLlibTestCase):
         """ Compare weights, intercept of sklearn, Spark GLMs
         """
         skl_weights = Vectors.dense(skl.coef_.flatten())
-        self.assertEqual(skl_weights, spark.weights)
+        self.assertEqual(skl_weights, spark.coefficients)
         self.assertEqual(skl.intercept_, spark.intercept)
 
     def test_LogisticRegression_skl2spark(self):

--- a/python/spark_sklearn/converter_test.py
+++ b/python/spark_sklearn/converter_test.py
@@ -1,6 +1,8 @@
+
 from scipy.sparse import csr_matrix
 from sklearn.linear_model import LogisticRegression as SKL_LogisticRegression
 from sklearn.linear_model import LinearRegression as SKL_LinearRegression
+import unittest
 
 from pyspark.ml.linalg import Vectors
 from pyspark.ml.regression import LinearRegression, LinearRegressionModel
@@ -8,8 +10,6 @@ from pyspark.ml.classification import LogisticRegression, LogisticRegressionMode
 
 from spark_sklearn.test_utils import MLlibTestCase, fixtureReuseSparkSession
 from spark_sklearn import Converter
-
-import unittest
 
 @fixtureReuseSparkSession
 class ConverterTests(MLlibTestCase):

--- a/python/spark_sklearn/converter_test.py
+++ b/python/spark_sklearn/converter_test.py
@@ -9,6 +9,8 @@ from pyspark.ml.classification import LogisticRegression, LogisticRegressionMode
 from spark_sklearn.test_utils import MLlibTestCase, fixtureReuseSparkSession
 from spark_sklearn import Converter
 
+import unittest
+
 @fixtureReuseSparkSession
 class ConverterTests(MLlibTestCase):
 
@@ -70,6 +72,7 @@ class ConverterTests(MLlibTestCase):
 @fixtureReuseSparkSession
 class CSRVectorUDTTests(MLlibTestCase):
 
+    @unittest.skip("CSR Matrix support not present for Spark 2.0 - see issue #24")
     def test_scipy_sparse(self):
         data = [(self.list2csr([0.1, 0.2]),)]
         df = self.sql.createDataFrame(data, ["features"])

--- a/python/spark_sklearn/converter_test.py
+++ b/python/spark_sklearn/converter_test.py
@@ -6,9 +6,10 @@ from pyspark.mllib.linalg import Vectors
 from pyspark.ml.regression import LinearRegression, LinearRegressionModel
 from pyspark.ml.classification import LogisticRegression, LogisticRegressionModel
 
-from spark_sklearn.test_utils import MLlibTestCase
+from spark_sklearn.test_utils import MLlibTestCase, fixtureReuseSparkSession
 from spark_sklearn import Converter
 
+@fixtureReuseSparkSession
 class ConverterTests(MLlibTestCase):
 
     def setUp(self):
@@ -66,6 +67,7 @@ class ConverterTests(MLlibTestCase):
         self.assertEqual(pd.features[0][0,0], 0.1)
         self.assertEqual(pd.features[0][0,1], 0.2)
 
+@fixtureReuseSparkSession
 class CSRVectorUDTTests(MLlibTestCase):
 
     def test_scipy_sparse(self):

--- a/python/spark_sklearn/test_utils.py
+++ b/python/spark_sklearn/test_utils.py
@@ -17,7 +17,7 @@ from scipy.sparse import csr_matrix
 
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
-from pyspark.mllib.linalg import Vectors
+from pyspark.ml.linalg import Vectors
 
 # Used as deocrator to have one PySpark SparkSession per fixture.
 def fixtureReuseSparkSession(cls):

--- a/python/spark_sklearn/test_utils.py
+++ b/python/spark_sklearn/test_utils.py
@@ -19,7 +19,10 @@ from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.ml.linalg import Vectors
 
-# Used as deocrator to have one PySpark SparkSession per fixture.
+# Used as decorator to wrap around a class deriving from unittest.TestCase. Wraps current
+# unittest methods setUpClass() and tearDownClass(), invoked by the nosetest command before
+# and after unit tests are run. This enables us to create one PySpark SparkSession per
+# test fixture. The session can be referred to with self.spark or ClassName.spark.
 def fixtureReuseSparkSession(cls):
     setup = getattr(cls, 'setUpClass', None)
     teardown = getattr(cls, 'tearDownClass', None)
@@ -29,7 +32,9 @@ def fixtureReuseSparkSession(cls):
     def tearDownClass(cls):
         if cls.spark:
             cls.spark.stop()
-            SparkSession._instantiatedContext = None
+            # Next session will attempt to reuse the previous stopped
+            # SparkContext if it's not cleared.
+            SparkSession._instantiatedContext = None 
         cls.spark = None
         if teardown: teardown()
 

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -14,6 +14,7 @@ class AllTests(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         super(AllTests, cls).tearDownClass()
+        # Restore sklearn module to the original state after done testing this fixture.
         sklearn.grid_search.GridSearchCV = sklearn.grid_search.GridSearchCV_original
         del sklearn.grid_search.GridSearchCV_original
 

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -23,8 +23,8 @@ class SPGridSearchWrapper(GridSearchCV):
                  n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise'):
       super(SPGridSearchWrapper, self).__init__(AllTests.spark.sparkContext, estimator, param_grid,
-                                                scoring, fit_params, n_jobs, iid, refit, cv, verbose,
-                                                pre_dispatch, error_score)
+                                                scoring, fit_params, n_jobs, iid, refit, cv,
+                                                verbose, pre_dispatch, error_score)
 
     # These methods do not raise ValueError but something different
 _blacklist = set(['test_pickle',

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -1,48 +1,54 @@
 import unittest
 
 import sklearn.grid_search
-
 from spark_sklearn import GridSearchCV
-from spark_sklearn.test_utils import create_sc
+from spark_sklearn.test_utils import fixtureReuseSparkSession
 # Overwrite the sklearn GridSearch in this suite so that we can run the same tests with the same
 # parameters.
 
-sc = create_sc()
+
+@fixtureReuseSparkSession
+class AllTests(unittest.TestCase):
+  
+    # After testing, make sure to revert sklearn to normal (see _add_to_module())
+    @classmethod
+    def tearDownClass(cls):
+        super(AllTests, cls).tearDownClass()
+        sklearn.grid_search.GridSearchCV = sklearn.grid_search.GridSearchCV_original
+        del sklearn.grid_search.GridSearchCV_original
 
 class SPGridSearchWrapper(GridSearchCV):
-
-  def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
+    def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise'):
-    super(SPGridSearchWrapper, self).__init__(sc, estimator, param_grid, scoring, fit_params,
-            n_jobs, iid, refit, cv, verbose, pre_dispatch, error_score)
+      super(SPGridSearchWrapper, self).__init__(AllTests.spark.sparkContext, estimator, param_grid,
+                                                scoring, fit_params, n_jobs, iid, refit, cv, verbose,
+                                                pre_dispatch, error_score)
 
-SKGridSearchCV = sklearn.grid_search.GridSearchCV
-sklearn.grid_search.GridSearchCV = SPGridSearchWrapper
-sklearn.grid_search.GridSearchCV_original = SKGridSearchCV
-from sklearn.tests import test_grid_search
+    # These methods do not raise ValueError but something different
+_blacklist = set(['test_pickle',
+                  'test_grid_search_precomputed_kernel_error_nonsquare',
+                  'test_grid_search_precomputed_kernel_error_kernel_function',
+                  'test_grid_search_precomputed_kernel',
+                  'test_grid_search_failing_classifier_raise',
+                  'test_grid_search_failing_classifier']) # This one we should investigate
 
-# These methods do not raise ValueError but something different
-blacklist = set(['test_pickle',
-                 'test_grid_search_precomputed_kernel_error_nonsquare',
-                 'test_grid_search_precomputed_kernel_error_kernel_function',
-                 'test_grid_search_precomputed_kernel',
-                 'test_grid_search_failing_classifier_raise',
-                 'test_grid_search_failing_classifier']) # This one we should investigate
-
-def all_methods():
-  return [(mname, method) for (mname, method) in test_grid_search.__dict__.items()
-          if mname.startswith("test_") and mname not in blacklist]
-
-class AllTests(unittest.TestCase):
-  pass
-
-def create_method(method):
+def _create_method(method):
     def do_test_expected(*kwargs):
-      method()
+        method()
     return do_test_expected
+        
+def _add_to_module():
+    SKGridSearchCV = sklearn.grid_search.GridSearchCV
+    sklearn.grid_search.GridSearchCV = SPGridSearchWrapper
+    sklearn.grid_search.GridSearchCV_original = SKGridSearchCV
+    from sklearn.tests import test_grid_search
+    all_methods = [(mname, method) for (mname, method) in test_grid_search.__dict__.items()
+                   if mname.startswith("test_") and mname not in _blacklist]
 
-for name, method in all_methods():
-  test_method = create_method(method)
-  test_method.__name__ = name
-  setattr (AllTests, test_method.__name__, test_method)
+    for name, method in all_methods:
+        method_for_test = _create_method(method)
+        method_for_test.__name__ = name
+        setattr (AllTests, method.__name__, method_for_test)
+
+_add_to_module()

--- a/python/spark_sklearn/tests/test_grid_search_2.py
+++ b/python/spark_sklearn/tests/test_grid_search_2.py
@@ -3,10 +3,6 @@ import scipy
 from sklearn.linear_model import Lasso as SKL_Lasso
 from sklearn.feature_extraction.text import HashingVectorizer as SKL_HashingVectorizer
 from sklearn.feature_extraction.text import TfidfTransformer as SKL_TfidfTransformer
-try:
-    from sklearn.grid_search import GridSearchCV_original as SKL_GridSearchCV
-except ImportError:
-    from sklearn.grid_search import GridSearchCV as SKL_GridSearchCV
 from sklearn.pipeline import Pipeline as SKL_Pipeline
 from sklearn import svm, grid_search, datasets
 import sys
@@ -26,8 +22,9 @@ from pyspark.ml.feature import HashingTF, Tokenizer
 from spark_sklearn.converter import Converter
 from spark_sklearn.grid_search import GridSearchCV
 
-from spark_sklearn.test_utils import MLlibTestCase
+from spark_sklearn.test_utils import MLlibTestCase, fixtureReuseSparkSession
 
+@fixtureReuseSparkSession
 class CVTests2(MLlibTestCase):
 
     def setUp(self):
@@ -49,7 +46,7 @@ class CVTests2(MLlibTestCase):
         b2 = clf2.estimator
         self.assertEqual(b1.get_params(), b2.get_params())
 
-
+@fixtureReuseSparkSession
 class CVTests(MLlibTestCase):
 
     def setUp(self):

--- a/python/spark_sklearn/util.py
+++ b/python/spark_sklearn/util.py
@@ -32,7 +32,6 @@ def _call_java(sc, java_obj, name, *args):
     Method copied from pyspark.ml.wrapper.  Uses private Spark APIs.
     """
     m = getattr(java_obj, name)
-    sc = _wrap_sc(sc)
     java_args = [_py2java(sc, arg) for arg in args]
     return _java2py(sc, m(*java_args))
 

--- a/python/spark_sklearn/util.py
+++ b/python/spark_sklearn/util.py
@@ -4,7 +4,7 @@ import uuid
 from pyspark import SparkContext
 
 # WARNING: These are private Spark APIs.
-from pyspark.mllib.common import _py2java, _java2py
+from pyspark.ml.common import _py2java, _java2py
 
 def _jvm():
     """
@@ -17,39 +17,24 @@ def _jvm():
     else:
         raise AttributeError("Cannot load _jvm from SparkContext. Is SparkContext initialized?")
 
-# 2.0.0-SNAPSHOT doesn't have pyspark.ml.common, so we fake its functionality here
-# TODO once pyspark/ml/common.py is present in the snapshot, get rid of this painful hack.
-def _hide_serde(sc):
-    sc._jvm.OldSerDe = sc._jvm.SerDe
-    sc._jvm.SerDe = sc._jvm.MLSerDe
-def _recover_serde(sc):
-    sc._jvm.SerDe = sc._jvm.OldSerDe
-    del sc._jvm.OldSerDe
-
 def _new_java_obj(sc, java_class, *args):
     """
     Construct a new Java object.
     """
-    _hide_serde(sc)
     java_obj = _jvm()
     for name in java_class.split("."):
         java_obj = getattr(java_obj, name)
     java_args = [_py2java(sc, arg) for arg in args]
-    _recover_serde(sc)
     return java_obj(*java_args)
 
 def _call_java(sc, java_obj, name, *args):
     """
     Method copied from pyspark.ml.wrapper.  Uses private Spark APIs.
     """
-    _hide_serde(sc)
     m = getattr(java_obj, name)
     sc = _wrap_sc(sc)
     java_args = [_py2java(sc, arg) for arg in args]
-    res = _java2py(sc, m(*java_args))
-    _recover_serde(sc)
-    return res
-
+    return _java2py(sc, m(*java_args))
 
 def _randomUID(cls):
     """

--- a/python/spark_sklearn/util.py
+++ b/python/spark_sklearn/util.py
@@ -4,7 +4,7 @@ import uuid
 from pyspark import SparkContext
 
 # WARNING: These are private Spark APIs.
-from pyspark.mllib.common import _py2java, _java2py
+from pyspark.ml.common import _py2java, _java2py
 
 def _jvm():
     """

--- a/python/spark_sklearn/util.py
+++ b/python/spark_sklearn/util.py
@@ -17,23 +17,38 @@ def _jvm():
     else:
         raise AttributeError("Cannot load _jvm from SparkContext. Is SparkContext initialized?")
 
+# 2.0.0-SNAPSHOT doesn't have pyspark.ml.common, so we fake its functionality here
+# TODO once pyspark/ml/common.py is present in the snapshot, get rid of this painful hack.
+def _hide_serde(sc):
+    sc._jvm.OldSerDe = sc._jvm.SerDe
+    sc._jvm.SerDe = sc._jvm.MLSerDe
+def _recover_serde(sc):
+    sc._jvm.SerDe = sc._jvm.OldSerDe
+    del sc._jvm.OldSerDe
+
 def _new_java_obj(sc, java_class, *args):
     """
     Construct a new Java object.
     """
+    _hide_serde(sc)
     java_obj = _jvm()
     for name in java_class.split("."):
         java_obj = getattr(java_obj, name)
     java_args = [_py2java(sc, arg) for arg in args]
+    _recover_serde(sc)
     return java_obj(*java_args)
 
 def _call_java(sc, java_obj, name, *args):
     """
     Method copied from pyspark.ml.wrapper.  Uses private Spark APIs.
     """
+    _hide_serde(sc)
     m = getattr(java_obj, name)
+    sc = _wrap_sc(sc)
     java_args = [_py2java(sc, arg) for arg in args]
-    return _java2py(sc, m(*java_args))
+    res = _java2py(sc, m(*java_args))
+    _recover_serde(sc)
+    return res
 
 
 def _randomUID(cls):

--- a/python/spark_sklearn/util.py
+++ b/python/spark_sklearn/util.py
@@ -4,7 +4,7 @@ import uuid
 from pyspark import SparkContext
 
 # WARNING: These are private Spark APIs.
-from pyspark.ml.common import _py2java, _java2py
+from pyspark.mllib.common import _py2java, _java2py
 
 def _jvm():
     """


### PR DESCRIPTION
In depth changes:

(1) modify README to reflect new version dep

(2) modify test script to unfold arguments the expected way (causes some problems if you try to pass multiple arguments)

(3) Moved a global sc context to a fixture-dependent context, which for code reuse was wrapped to a decorator.

(4) Fixed a bug where test_grid_search_2.py would use a "muddled" sklearn module, changed by test_grid_search_1.py to reuse the sklearn unit tests for free - search_2 expected a "fresh" sklearn module.

Note that this commit reworked some of the code in the converter_tests, which failed before.
[Errors on new branch](https://gist.github.com/vlad17/f16afce0a6b1788c299d097c64a34544)
[Different errors on prev master](https://gist.github.com/vlad17/f0e16184fe8fc4fae8a896b7bcf38d10)