### PR TITLE
Fix doctest

### DIFF
--- a/python/run-doctests.sh
+++ b/python/run-doctests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# The current directory of the script.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ALL_MODULES=$(cd $DIR && echo 'import spark_sklearn, inspect; print(" ".join("spark_sklearn." + x[0] for x in inspect.getmembers(spark_sklearn, inspect.ismodule)))' | python)
+
+$DIR/run-tests.sh $ALL_MODULES --with-doctest $@

--- a/python/run-doctests.sh
+++ b/python/run-doctests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Runs only the doctests. Additional flags are passed through to nose.
 
 # The current directory of the script.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Runs both doctests and unit tests by default, otherwise hands arguments over to nose.
 
 # assumes run from python/ directory
 if [ -z "$SPARK_HOME" ]; then

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -27,8 +27,8 @@ export PYTHONPATH=$PYTHONPATH:/home/travis/miniconda/envs/test-environment/lib/p
 set -e
 
 if [ "$#" = 0 ]; then
-    ARGS="--all-modules"
+    ARGS="--nologcapture --all-modules --verbose --with-doctest"
 else
     ARGS="$@"
 fi
-exec nosetests -v $ARGS -w $DIR
+exec nosetests $ARGS --where $DIR

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -84,10 +84,11 @@ class GridSearchCV(BaseSearchCV):
     >>> from sklearn import svm, datasets
     >>> from spark_sklearn import GridSearchCV
     >>> from pyspark.sql import SparkSession
+    >>> from spark_sklearn.util import createLocalSparkSession
+    >>> spark = createLocalSparkSession()
     >>> iris = datasets.load_iris()
     >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
     >>> svr = svm.SVC()
-    >>> spark = SparkSession.builder.master("local").getOrCreate()
     >>> clf = GridSearchCV(spark.sparkContext, svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -81,12 +81,14 @@ class GridSearchCV(BaseSearchCV):
 
     Examples
     --------
-    >>> from sklearn import svm,  datasets
+    >>> from sklearn import svm, datasets
     >>> from spark_sklearn import GridSearchCV
+    >>> from pyspark.sql import SparkSession
     >>> iris = datasets.load_iris()
     >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
     >>> svr = svm.SVC()
-    >>> clf = GridSearchCV(svr, parameters)
+    >>> spark = SparkSession.builder.master("local").getOrCreate()
+    >>> clf = GridSearchCV(spark.sparkContext, svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     GridSearchCV(cv=None, error_score=...,
@@ -98,7 +100,7 @@ class GridSearchCV(BaseSearchCV):
            fit_params={}, iid=..., n_jobs=1,
            param_grid=..., pre_dispatch=..., refit=...,
            scoring=..., verbose=...)
-
+    >>> spark.stop(); SparkSession._instantiatedContext = None
 
     Attributes
     ----------

--- a/python/spark_sklearn/group_apply.py
+++ b/python/spark_sklearn/group_apply.py
@@ -58,7 +58,8 @@ def gapply(grouped_data, func, schema, *cols):
     >>> import pandas as pd
     >>> from pyspark.sql import SparkSession
     >>> from spark_sklearn.group_apply import gapply
-    >>> spark = SparkSession.builder.master("local").getOrCreate()
+    >>> from spark_sklearn.util import createLocalSparkSession
+    >>> spark = createLocalSparkSession()
     >>> df = (spark
     ...     .createDataFrame([Row(course="dotNET", year=2012, earnings=10000),
     ...                       Row(course="Java",   year=2012, earnings=20000),

--- a/python/spark_sklearn/group_apply.py
+++ b/python/spark_sklearn/group_apply.py
@@ -163,7 +163,3 @@ def gapply(grouped_data, func, schema, *cols):
     explodedDF = outputAggDF.select(explode(*outputAggDF).alias("gapply"))
     # automatically retrieves nested schema column names
     return explodedDF.select("gapply.*")
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/python/spark_sklearn/group_apply.py
+++ b/python/spark_sklearn/group_apply.py
@@ -56,6 +56,9 @@ def gapply(grouped_data, func, schema, *cols):
     no keys can be prepended.
 
     >>> import pandas as pd
+    >>> from pyspark.sql import SparkSession
+    >>> from spark_sklearn.group_apply import gapply
+    >>> spark = SparkSession.builder.master("local").getOrCreate()
     >>> df = (spark
     ...     .createDataFrame([Row(course="dotNET", year=2012, earnings=10000),
     ...                       Row(course="Java",   year=2012, earnings=20000),
@@ -94,6 +97,7 @@ def gapply(grouped_data, func, schema, *cols):
     |dotNET|2013|   48000|
     +------+----+--------+
     <BLANKLINE>
+    >>> spark.stop(); SparkSession._instantiatedContext = None
     """
     import pandas as pd
     minPandasVersion = '0.7.1'
@@ -159,17 +163,6 @@ def gapply(grouped_data, func, schema, *cols):
     # automatically retrieves nested schema column names
     return explodedDF.select("gapply.*")
 
-def _test():
-    import doctest
-    spark = SparkSession.builder \
-        .master("local") \
-        .appName("sql.group tests")\
-        .getOrCreate()
-    sc = spark.sparkContext
-    globs = globals().copy()
-    globs['spark'] = spark
-    doctest.testmod(globs=globs)
-    spark.stop()
-
 if __name__ == "__main__":
-    _test()
+    import doctest
+    doctest.testmod()

--- a/python/spark_sklearn/keyed_models.py
+++ b/python/spark_sklearn/keyed_models.py
@@ -21,16 +21,16 @@ and aggregated dataframe.
 >>> spark = createLocalSparkSession()
 >>> df = spark.createDataFrame([(user,
 ...                              Vectors.dense([i, i ** 2, i ** 3]),
-...                              user + i + 2 * i ** 2 + 3 * i ** 3)
+...                              0.0 + user + i + 2 * i ** 2 + 3 * i ** 3)
 ...                             for user in range(3) for i in range(5)])
 >>> df = df.toDF("key", "features", "y")
 >>> df.where("5 < y and y < 10").sort("key", "y").show()
 +---+-------------+---+
 |key|     features|  y|
 +---+-------------+---+
-|  0|[1.0,1.0,1.0]|  6|
-|  1|[1.0,1.0,1.0]|  7|
-|  2|[1.0,1.0,1.0]|  8|
+|  0|[1.0,1.0,1.0]|6.0|
+|  1|[1.0,1.0,1.0]|7.0|
+|  2|[1.0,1.0,1.0]|8.0|
 +---+-------------+---+
 <BLANKLINE>
 >>> km = KeyedEstimator(sklearnEstimator=LinearRegression(), yCol="y").fit(df)
@@ -58,11 +58,11 @@ In the following, we only show one point for simplicity, but the test data can c
 points for multiple different keys.
 
 >>> input = spark.createDataFrame([(0, Vectors.dense(3, 1, -1))]).toDF("key", "features")
->>> km.transform(input).show()
+>>> km.transform(input).withColumn("output", udf(round)("output")).show()
 +---+--------------+------+
 |key|      features|output|
 +---+--------------+------+
-|  0|[3.0,1.0,-1.0]|     1|
+|  0|[3.0,1.0,-1.0]|   2.0|
 +---+--------------+------+
 <BLANKLINE>
 >>> spark.stop(); SparkSession._instantiatedContext = None # clear hidden SparkContext for reuse

--- a/python/spark_sklearn/keyed_models.py
+++ b/python/spark_sklearn/keyed_models.py
@@ -14,9 +14,11 @@ and aggregated dataframe.
 
 >>> from sklearn.linear_model import LinearRegression
 >>> from pyspark.ml.linalg import Vectors
->>> from pyspark.sql import SparkSession
 >>> from pyspark.sql.functions import udf
->>> spark = SparkSession.builder.master("local").getOrCreate()
+>>> from pyspark.sql import SparkSession
+>>> from spark_sklearn.util import createLocalSparkSession
+>>> from spark_sklearn.keyed_models import KeyedEstimator
+>>> spark = createLocalSparkSession()
 >>> df = spark.createDataFrame([(user,
 ...                              Vectors.dense([i, i ** 2, i ** 3]),
 ...                              user + i + 2 * i ** 2 + 3 * i ** 3)

--- a/python/spark_sklearn/keyed_models.py
+++ b/python/spark_sklearn/keyed_models.py
@@ -34,10 +34,10 @@ and aggregated dataframe.
 +---+-------------+---+
 <BLANKLINE>
 >>> km = KeyedEstimator(sklearnEstimator=LinearRegression(), yCol="y").fit(df)
+>>> def printFloat(x): return '{:.2f}'.format(round(x, 2))
 >>> def printModel(model):
-...     numeric = "{:.2f}"
-...     coef = "[" + ", ".join(numeric.format(x) for x in model.coef_) + "]"
-...     intercept = numeric.format(model.intercept_)
+...     coef = "[" + ", ".join(map(printFloat, model.coef_)) + "]"
+...     intercept = printFloat(model.intercept_)
 ...     return "intercept: {} coef: {}".format(intercept, coef)
 ...
 >>> km.keyedModels.columns
@@ -58,11 +58,11 @@ In the following, we only show one point for simplicity, but the test data can c
 points for multiple different keys.
 
 >>> input = spark.createDataFrame([(0, Vectors.dense(3, 1, -1))]).toDF("key", "features")
->>> km.transform(input).withColumn("output", udf(round)("output")).show()
+>>> km.transform(input).withColumn("output", udf(printFloat)("output")).show()
 +---+--------------+------+
 |key|      features|output|
 +---+--------------+------+
-|  0|[3.0,1.0,-1.0]|   2.0|
+|  0|[3.0,1.0,-1.0]|  2.00|
 +---+--------------+------+
 <BLANKLINE>
 >>> spark.stop(); SparkSession._instantiatedContext = None # clear hidden SparkContext for reuse

--- a/python/spark_sklearn/test_utils.py
+++ b/python/spark_sklearn/test_utils.py
@@ -29,7 +29,10 @@ def fixtureReuseSparkSession(cls):
     setup = getattr(cls, 'setUpClass', None)
     teardown = getattr(cls, 'tearDownClass', None)
     def setUpClass(cls):
-        cls.spark = SparkSession.builder.master("local").appName("Unit Tests").getOrCreate()
+        cls.spark = SparkSession.builder \
+                                .master("local[*]") \
+                                .appName("Unit Tests") \
+                                .getOrCreate()
         if setup:
             setup()
     def tearDownClass(cls):

--- a/python/spark_sklearn/test_utils.py
+++ b/python/spark_sklearn/test_utils.py
@@ -29,9 +29,12 @@ def fixtureReuseSparkSession(cls):
     setup = getattr(cls, 'setUpClass', None)
     teardown = getattr(cls, 'tearDownClass', None)
     def setUpClass(cls):
+        # use all cores to speed up testing
+        # disable the console progress bar so test names aren't overwritten
         cls.spark = SparkSession.builder \
                                 .master("local[*]") \
                                 .appName("Unit Tests") \
+                                .config("spark.ui.showConsoleProgress", "false") \
                                 .getOrCreate()
         if setup:
             setup()

--- a/python/spark_sklearn/test_utils.py
+++ b/python/spark_sklearn/test_utils.py
@@ -14,9 +14,10 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 
-from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.ml.linalg import Vectors
+
+from spark_sklearn.util import createLocalSparkSession
 
 # Used as decorator to wrap around a class deriving from unittest.TestCase. Wraps current
 # unittest methods setUpClass() and tearDownClass(), invoked by the nosetest command before
@@ -29,13 +30,7 @@ def fixtureReuseSparkSession(cls):
     setup = getattr(cls, 'setUpClass', None)
     teardown = getattr(cls, 'tearDownClass', None)
     def setUpClass(cls):
-        # use all cores to speed up testing
-        # disable the console progress bar so test names aren't overwritten
-        cls.spark = SparkSession.builder \
-                                .master("local[*]") \
-                                .appName("Unit Tests") \
-                                .config("spark.ui.showConsoleProgress", "false") \
-                                .getOrCreate()
+        cls.spark = createLocalSparkSession("Unit Tests")
         if setup:
             setup()
     def tearDownClass(cls):

--- a/python/spark_sklearn/tests/test_gapply.py
+++ b/python/spark_sklearn/tests/test_gapply.py
@@ -176,8 +176,6 @@ class GapplyConfTests(unittest.TestCase):
     def setUpClass(cls):
         super(GapplyConfTests, cls).setUpClass()
         cls.spark = SparkSession.builder \
-                                .master("local") \
-                                .appName("Unit Tests") \
                                 .config("spark.sql.retainGroupColumns", "false") \
                                 .getOrCreate()
 
@@ -188,8 +186,6 @@ class GapplyConfTests(unittest.TestCase):
         # the config is (for some stupid reason...) cached, which would make it get in
         # the way of other tests that expect a default configuration.
         cls.spark = SparkSession.builder \
-                                .master("local") \
-                                .appName("Unit Tests") \
                                 .config("spark.sql.retainGroupColumns", "true") \
                                 .getOrCreate()
 

--- a/python/spark_sklearn/util.py
+++ b/python/spark_sklearn/util.py
@@ -2,6 +2,7 @@
 import uuid
 
 from pyspark import SparkContext
+from pyspark.sql import SparkSession
 
 # WARNING: These are private Spark APIs.
 from pyspark.ml.common import _py2java, _java2py
@@ -41,3 +42,12 @@ def _randomUID(cls):
     concatenates the class name, "_", and 12 random hex chars.
     """
     return cls.__name__ + "_" + uuid.uuid4().hex[12:]
+
+def createLocalSparkSession(appName="spark-sklearn"):
+    """Generates a :class:`SparkSession` utilizing all local cores
+    with the progress bar disabled but otherwise default config."""
+    return SparkSession.builder \
+                       .master("local[*]") \
+                       .appName(appName) \
+                       .config("spark.ui.showConsoleProgress", "false") \
+                       .getOrCreate()


### PR DESCRIPTION
This PR does a couple of disparate things to reduce some technical debt.

1) Provide a way to run only doctests
2) Change the default test parameters to run doctests as well as normal tests
3) Fix broken doctests
4) Fix some broken imports
5) Use all cores when running Spark in tests (nose is serial so we're not utilizing full capacity). This improves speed by a factor of 4x for me on my 8 core machine.