### PR TITLE
Added randomized test seed-setting utility

### DIFF
--- a/python/spark_sklearn/test_utils.py
+++ b/python/spark_sklearn/test_utils.py
@@ -11,8 +11,11 @@ if sys.version_info[:2] <= (2, 6):
 else:
     import unittest
 import numpy as np
+import os
 import pandas as pd
+import random
 from scipy.sparse import csr_matrix
+import time
 
 from pyspark.sql import SparkSession
 from pyspark.ml.linalg import Vectors
@@ -87,3 +90,20 @@ def assertPandasAlmostEqual(actual, expected, convert=None, sortby=None):
     actual = normalize(actual)
     expected = normalize(expected)
     pd.util.testing.assert_almost_equal(actual, expected)
+
+# This unittest.TestCase subclass sets the random seed to be based on the time
+# that the test is run.
+#
+# If there is a SEED variable in the enviornment, then this is used as the seed.
+# Sets both random and numpy.random.
+#
+# Prints the seed to stdout before running each test case.
+class RandomTest(unittest.TestCase):
+    def setUp(self):
+        seed = os.getenv("SEED")
+        seed = np.uint32(seed if seed else time.time())
+
+        print('Random test using SEED={}'.format(seed))
+
+        random.seed(seed)
+        np.random.seed(seed)

--- a/python/spark_sklearn/tests/test_gapply.py
+++ b/python/spark_sklearn/tests/test_gapply.py
@@ -7,7 +7,7 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import *
 from pyspark.sql.tests import PythonOnlyPoint, PythonOnlyUDT, ExamplePoint, ExamplePointUDT
 
-from spark_sklearn.test_utils import fixtureReuseSparkSession, assertPandasAlmostEqual
+from spark_sklearn.test_utils import fixtureReuseSparkSession, assertPandasAlmostEqual, RandomTest
 from spark_sklearn import gapply
 
 def _assertPandasAlmostEqual(actual, expected):
@@ -23,7 +23,7 @@ def _emptyFunc(key, vals):
     return pd.DataFrame.from_records([])
 
 @fixtureReuseSparkSession
-class GapplyTests(unittest.TestCase):
+class GapplyTests(RandomTest):
 
     def test_gapply_empty(self):
         # Implicitly checks that pandas version is large enough (unit tests for the actual version
@@ -171,7 +171,7 @@ class GapplyTests(unittest.TestCase):
         _assertPandasAlmostEqual(actual, expected)
 
 @fixtureReuseSparkSession
-class GapplyConfTests(unittest.TestCase):
+class GapplyConfTests(RandomTest):
     @classmethod
     def setUpClass(cls):
         super(GapplyConfTests, cls).setUpClass()

--- a/python/spark_sklearn/tests/test_keyed_models.py
+++ b/python/spark_sklearn/tests/test_keyed_models.py
@@ -12,7 +12,7 @@ from pyspark.ml.linalg import Vectors
 import sklearn.base
 
 from spark_sklearn import KeyedEstimator, KeyedModel, SparkSklearnEstimator
-from spark_sklearn.test_utils import fixtureReuseSparkSession, assertPandasAlmostEqual
+from spark_sklearn.test_utils import fixtureReuseSparkSession, assertPandasAlmostEqual, RandomTest
 
 def _sortByComponentWeight(pca):
     zipped = zip(pca.components_, pca.explained_variance_ratio_)
@@ -31,7 +31,7 @@ def _assertPandasAlmostEqual(actual, expected, sortby):
     assertPandasAlmostEqual(actual, expected, convert=convert_estimators, sortby=sortby)
 
 @fixtureReuseSparkSession
-class KeyedModelTests(unittest.TestCase):
+class KeyedModelTests(RandomTest):
 
     NDIM = 5
 


### PR DESCRIPTION
Tested manually by running a single test with --nocapture (prints stdout immediately). Seed is printed correctly. If SEED env is set then the seed is set correctly.