### PR TITLE
Upgrade to Spark 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ cache:
     - $HOME/.cache/spark-versions
 env:
   matrix:
-    # TODO: remove snapshot dependency after 2.0.0 release
-    - SPARK_VERSION="2.0.1-SNAPSHOT" SPARK_BUILD="spark-$SPARK_VERSION-bin-hadoop2.6" SPARK_BUILD_URL="http://people.apache.org/~pwendell/spark-nightly/spark-branch-2.0-bin/latest/$SPARK_BUILD.tgz"
+    - SPARK_VERSION="2.0.0" SPARK_BUILD="spark-$SPARK_VERSION-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/$SPARK_BUILD.tgz"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Scikit-learn integration package for Apache Spark
+# Scikit-learn integration package for Apache Spark
 
 This package contains some tools to integrate the [Spark computing framework](http://spark.apache.org/) with the popular [scikit-learn machine library](http://scikit-learn.org/stable/). Among other tools:
  - train and evaluate multiple scikit-learn models in parallel. It is a distributed analog to the [multicore implementation](https://pythonhosted.org/joblib/parallel.html) included by default in [scikit-learn](http://scikit-learn.org/stable/).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project is also available as as [Spark package](http://spark-packages.org/p
 
 The developer version has the following requirements:
  - a recent release of scikit-learn. Release 0.17 has been tested, older versions may work too.
- - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details. NOTICE: currently, this package uses the nightly 2.0.0 snapshot, available [here](http://people.apache.org/~pwendell/spark-nightly/spark-branch-2.0-bin/latest/) (TODO: remove reference after 2.0.0 release).
+ - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)
  - Pandas, if using the Pandas integration or testing. Pandas==0.18 has been tested.
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 
 scalaVersion := "2.10.4"
 
-sparkVersion := "2.0.0-SNAPSHOT"
+sparkVersion := "2.0.0"
 
 spName := "databricks/spark-sklearn"
 
@@ -15,9 +15,6 @@ licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 
 // Add Spark components this package depends on, e.g, "mllib", ....
 sparkComponents ++= Seq("mllib")
-
-// TODO: remove after Spark 2.0.0 release:
-resolvers += "apache-snapshots" at "https://repository.apache.org/snapshots/"
 
 // uncomment and change the value below to change the directory where your zip artifact will be created
 // spDistDirectory := target.value

--- a/python/spark_sklearn/tests/test_gapply.py
+++ b/python/spark_sklearn/tests/test_gapply.py
@@ -85,6 +85,10 @@ class GapplyTests(RandomTest):
         dataGen = lambda: (random.randrange(GapplyTests.NVALS), random.randrange(GapplyTests.NVALS))
         self.checkGapplyEquivalentToPandas(pandasAggFunction, dataType, dataGen)
 
+    @unittest.skip("""
+    python only UDTs can't be nested in arraytypes for now, see SPARK-15989
+    this is only available starting in Spark 2.0.1
+    """)
     def test_gapply_python_only_udt_val(self):
         def pandasAggFunction(series):
             x = float(series.apply(lambda pt: int(pt.x) + int(pt.y)).sum())

--- a/python/spark_sklearn/tests/test_gapply.py
+++ b/python/spark_sklearn/tests/test_gapply.py
@@ -33,7 +33,6 @@ class GapplyTests(RandomTest):
         gd = emptyLongLongDF.groupBy("a")
         self.assertEqual(gapply(gd, _emptyFunc, longLongSchema, "b").collect(), [])
 
-    @unittest.skip("Generating an empty dataframe after exploding fails, see SPARK-16179")
     def test_gapply_empty_schema(self):
         longLongSchema = StructType().add("a", LongType()).add("b", LongType())
         emptyLongLongDF = self.spark.createDataFrame([(1, 2)], schema=longLongSchema)
@@ -86,7 +85,6 @@ class GapplyTests(RandomTest):
         dataGen = lambda: (random.randrange(GapplyTests.NVALS), random.randrange(GapplyTests.NVALS))
         self.checkGapplyEquivalentToPandas(pandasAggFunction, dataType, dataGen)
 
-    @unittest.skip("python only UDTs can't be nested in arraytypes for now, see SPARK-15989")
     def test_gapply_python_only_udt_val(self):
         def pandasAggFunction(series):
             x = float(series.apply(lambda pt: int(pt.x) + int(pt.y)).sum())

--- a/python/spark_sklearn/tests/test_keyed_models.py
+++ b/python/spark_sklearn/tests/test_keyed_models.py
@@ -307,7 +307,6 @@ class KeyedModelTests(RandomTest):
                                        sklearnEstimator=LinearRegression(), yCol="myy",
                                        xCol="myfeatures", keyCols=["mykey1", "mykey2"])
 
-    @unittest.skip("python vector nulls are unsupported for now, see SPARK-16175")
     def test_surprise_key(self):
         ke = KeyedEstimator(sklearnEstimator=PCA())
         schema = StructType().add("features", LongType()).add("key", LongType())
@@ -323,7 +322,7 @@ class KeyedModelTests(RandomTest):
         df = km.transform(df)
 
         self.assertEqual(df.collect(), [(1, 2, None)])
-        self.assertEqual(km.keyedModels.dtypes,
+        self.assertEqual(df.dtypes,
                          [("features", "bigint"),
                           ("key", "bigint"),
                           ("output", "vector")])


### PR DESCRIPTION
This patch updates the CI and sbt build scripts to Spark 2.0. It resolves issue #34 .

This enables us to test previously skipped tests from a few issues as well, resolving those too #31 #39.