### PR TITLE
[53] Update compatibility to Sklearn .18.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18 numpy==1.8.0
   - source activate test-environment
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18 numpy==1.11.0
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18
   - source activate test-environment
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.17.0 nose=1.3.7 pandas=0.18
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18
   - source activate test-environment
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.cache/spark-versions
 env:
   matrix:
-    - SPARK_VERSION="2.0.0" SPARK_BUILD="spark-$SPARK_VERSION-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/$SPARK_BUILD.tgz"
+    - SPARK_VERSION="2.1.1" SPARK_BUILD="spark-$SPARK_VERSION-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/$SPARK_BUILD.tgz"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18 numpy==1.8.0
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18 numpy==1.11.0
   - source activate test-environment
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.0 nose=1.3.7 pandas=0.18
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scikit-learn==0.18.1 nose=1.3.7 pandas=0.18
   - source activate test-environment
 
 script:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project is also available as as [Spark package](http://spark-packages.org/p
 
 The developer version has the following requirements:
  - a recent release of scikit-learn. Release 0.17 has been tested, older versions may work too.
- - Spark >= 2.0. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
+ - Spark >= 2.1.1. Spark may be downloaded from the [Spark official website](http://spark.apache.org/). In order to use this package, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)
  - Pandas, if using the Pandas integration or testing. Pandas==0.18 has been tested.
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 
 scalaVersion := "2.10.4"
 
-sparkVersion := "2.0.0"
+sparkVersion := "2.1.1"
 
 spName := "databricks/spark-sklearn"
 

--- a/python/README.md
+++ b/python/README.md
@@ -20,13 +20,9 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 ## Installation
 
 This package has the following requirements:
-<<<<<<< HEAD
- - Sklearn version >= .18.1
- - Spark >= 2.1.1 Spark may be downloaded from the
-=======
+This package has the following requirements:
  - Sklearn version >= 0.18.1
- - Spark >= 2.0. Spark may be downloaded from the
->>>>>>> Fixed specified sklearn version.
+ - Spark >= 2.1.1 Spark may be downloaded from the
  [Spark official website](http://spark.apache.org/). In order to use spark-sklearn, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)
 

--- a/python/README.md
+++ b/python/README.md
@@ -20,7 +20,7 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 ## Installation
 
 This package has the following requirements:
- - a recent version of scikit-learn. Version 0.17 has been tested, older versions may work too.
+ - Sklearn version >= .18.1
  - Spark >= 2.1.1 Spark may be downloaded from the
  [Spark official website](http://spark.apache.org/). In order to use spark-sklearn, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)

--- a/python/README.md
+++ b/python/README.md
@@ -21,7 +21,7 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 
 This package has the following requirements:
  - a recent version of scikit-learn. Version 0.17 has been tested, older versions may work too.
- - Spark >= 2.0. Spark may be downloaded from the
+ - Spark >= 2.1.1 Spark may be downloaded from the
  [Spark official website](http://spark.apache.org/). In order to use spark-sklearn, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)
 

--- a/python/README.md
+++ b/python/README.md
@@ -20,8 +20,13 @@ This package is released under the Apache 2.0 license. See the LICENSE file.
 ## Installation
 
 This package has the following requirements:
+<<<<<<< HEAD
  - Sklearn version >= .18.1
  - Spark >= 2.1.1 Spark may be downloaded from the
+=======
+ - Sklearn version >= 0.18.1
+ - Spark >= 2.0. Spark may be downloaded from the
+>>>>>>> Fixed specified sklearn version.
  [Spark official website](http://spark.apache.org/). In order to use spark-sklearn, you need to use the pyspark interpreter or another Spark-compliant python interpreter. See the [Spark guide](https://spark.apache.org/docs/latest/programming-guide.html#overview) for more details.
  - [nose](https://nose.readthedocs.org) (testing dependency only)
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 # This file should list any python package dependencies.
 scikit-learn==0.18.1
-numpy==1.8.0
+numpy==1.11.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
 # This file should list any python package dependencies.
-scikit-learn==0.17.1
+scikit-learn==0.18.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 # This file should list any python package dependencies.
 scikit-learn==0.18.1
+numpy==1.8.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,2 @@
 # This file should list any python package dependencies.
 scikit-learn==0.18.1
-numpy==1.11.0

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -10,4 +10,4 @@ if [ "$#" = 0 ]; then
 else
     ARGS="$@"
 fi
-exec nosetests $ARGS --where $DIR --nocapture
+exec nosetests $ARGS --where $DIR

--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -10,4 +10,4 @@ if [ "$#" = 0 ]; then
 else
     ARGS="$@"
 fi
-exec nosetests $ARGS --where $DIR
+exec nosetests $ARGS --where $DIR --nocapture

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
-INSTALL_REQUIRES = ["scikit-learn >= 0.17"]
+INSTALL_REQUIRES = ["scikit-learn >= 0.18"]
 
 # Project root
 ROOT = os.path.abspath(os.getcwd() + "/")

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
-INSTALL_REQUIRES = ["scikit-learn >= 0.18"]
+INSTALL_REQUIRES = ["scikit-learn >= 0.18.1"]
 
 # Project root
 ROOT = os.path.abspath(os.getcwd() + "/")

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -7,6 +7,7 @@ import sys
 from itertools import product
 from collections import Sized, Mapping, namedtuple, defaultdict, Sequence
 from functools import partial
+import warnings
 import numpy as np
 from scipy.stats import rankdata
 
@@ -201,8 +202,22 @@ class GridSearchCV(BaseSearchCV):
 
     #ef _fit(self, X, y, parameter_iterable, groups=None):
     def fit(self, X, y=None, groups=None, **fit_params):
+
+      if self.fit_params is not None:
+        warnings.warn('"fit_params" as a constructor argument was '
+                      'deprecated in version 0.19 and will be removed '
+                      'in version 0.21. Pass fit parameters to the '
+                      '"fit" method instead.', DeprecationWarning)
+        if fit_params:
+            warnings.warn('Ignoring fit_params passed as a constructor '
+                          'argument in favor of keyword arguments to '
+                          'the "fit" method.', RuntimeWarning)
+        else:
+            fit_params = self.fit_params
+
         estimator = self.estimator
         cv = check_cv(self.cv, y, classifier=is_classifier(estimator))
+
         self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
 
         X, y, groups = indexable(X, y, groups)
@@ -212,10 +227,10 @@ class GridSearchCV(BaseSearchCV):
         #candidate_params = parameter_iterable # change later
         candidate_params = ParameterGrid(self.param_grid)
         n_candidates = len(candidate_params)
-        # if self.verbose > 0:
-        #     print("Fitting {0} folds for each of {1} candidates, totalling"
-        #           " {2} fits".format(n_splits, n_candidates,
-        #                              n_candidates * n_splits))
+        if self.verbose > 0:
+            print("Fitting {0} folds for each of {1} candidates, totalling"
+                  " {2} fits".format(n_splits, n_candidates,
+                                     n_candidates * n_splits))
 
         base_estimator = clone(self.estimator)
 

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -243,7 +243,7 @@ class GridSearchCV(BaseSearchCV):
                  pre_dispatch='2*n_jobs', error_score='raise', return_train_score=True):
         super(GridSearchCV, self).__init__(
             estimator=estimator, scoring=scoring, fit_params=fit_params, n_jobs=n_jobs, iid=iid,
-            refit=retfit, cv=cv, verbose=verbose, pre_dispatch=pre_dispatch, error_score=error_score,
+            refit=refit, cv=cv, verbose=verbose, pre_dispatch=pre_dispatch, error_score=error_score,
             return_train_score=return_train_score)
         self.sc = sc
         self.param_grid = param_grid

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -12,12 +12,10 @@ import numpy as np
 from scipy.stats import rankdata
 
 from sklearn.base import BaseEstimator, is_classifier, clone
-#from sklearn.cross_validation import KFold, check_cv, _fit_and_score, _safe_split
-from sklearn.model_selection import KFold, check_cv, ParameterGrid # new
-from sklearn.model_selection._validation import _fit_and_score # new
-from sklearn.utils.metaestimators import _safe_split  # new
-#from sklearn.grid_search import BaseSearchCV, _check_param_grid, ParameterGrid, _CVScoreTuple
-from sklearn.model_selection._search import BaseSearchCV, _check_param_grid, _CVScoreTuple # new
+from sklearn.model_selection import KFold, check_cv, ParameterGrid
+from sklearn.model_selection._validation import _fit_and_score
+from sklearn.utils.metaestimators import _safe_split
+from sklearn.model_selection._search import BaseSearchCV, _check_param_grid, _CVScoreTuple
 from sklearn.metrics.scorer import check_scoring
 from sklearn.utils.fixes import MaskedArray
 from sklearn.utils.validation import _num_samples, indexable
@@ -56,6 +54,11 @@ class GridSearchCV(BaseSearchCV):
 
     fit_params : dict, optional
         Parameters to pass to the fit method.
+         
+         .. deprecated:: 0.19
+           ``fit_params`` as a constructor argument was deprecated in version
+           0.19 and will be removed in version 0.21. Pass fit parameters to
+           the ``fit`` method instead..
 
     n_jobs : int, default 1
         This parameter is not used and kept for compatibility.
@@ -119,30 +122,73 @@ class GridSearchCV(BaseSearchCV):
 
     Attributes
     ----------
-    grid_scores_ : list of named tuples
-        Contains scores for all parameter combinations in param_grid.
-        Each entry corresponds to one parameter setting.
-        Each named tuple has the attributes:
-
-            * ``parameters``, a dict of parameter settings
-            * ``mean_validation_score``, the mean score over the
-              cross-validation folds
-            * ``cv_validation_scores``, the list of scores for each fold
-
+    cv_results_ : dict of numpy (masked) ndarrays
+        A dict with keys as column headers and values as columns, that can be
+        imported into a pandas ``DataFrame``.
+        For instance the below given table
+        +------------+-----------+------------+-----------------+---+---------+
+        |param_kernel|param_gamma|param_degree|split0_test_score|...|rank_....|
+        +============+===========+============+=================+===+=========+
+        |  'poly'    |     --    |      2     |        0.8      |...|    2    |
+        +------------+-----------+------------+-----------------+---+---------+
+        |  'poly'    |     --    |      3     |        0.7      |...|    4    |
+        +------------+-----------+------------+-----------------+---+---------+
+        |  'rbf'     |     0.1   |     --     |        0.8      |...|    3    |
+        +------------+-----------+------------+-----------------+---+---------+
+        |  'rbf'     |     0.2   |     --     |        0.9      |...|    1    |
+        +------------+-----------+------------+-----------------+---+---------+
+        will be represented by a ``cv_results_`` dict of::
+            {
+            'param_kernel': masked_array(data = ['poly', 'poly', 'rbf', 'rbf'],
+                                         mask = [False False False False]...)
+            'param_gamma': masked_array(data = [-- -- 0.1 0.2],
+                                        mask = [ True  True False False]...),
+            'param_degree': masked_array(data = [2.0 3.0 -- --],
+                                         mask = [False False  True  True]...),
+            'split0_test_score'  : [0.8, 0.7, 0.8, 0.9],
+            'split1_test_score'  : [0.82, 0.5, 0.7, 0.78],
+            'mean_test_score'    : [0.81, 0.60, 0.75, 0.82],
+            'std_test_score'     : [0.02, 0.01, 0.03, 0.03],
+            'rank_test_score'    : [2, 4, 3, 1],
+            'split0_train_score' : [0.8, 0.9, 0.7],
+            'split1_train_score' : [0.82, 0.5, 0.7],
+            'mean_train_score'   : [0.81, 0.7, 0.7],
+            'std_train_score'    : [0.03, 0.03, 0.04],
+            'mean_fit_time'      : [0.73, 0.63, 0.43, 0.49],
+            'std_fit_time'       : [0.01, 0.02, 0.01, 0.01],
+            'mean_score_time'    : [0.007, 0.06, 0.04, 0.04],
+            'std_score_time'     : [0.001, 0.002, 0.003, 0.005],
+            'params'             : [{'kernel': 'poly', 'degree': 2}, ...],
+            }
+        NOTE that the key ``'params'`` is used to store a list of parameter
+        settings dict for all the parameter candidates.
+        The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
+        ``std_score_time`` are all in seconds.
+    
     best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
         on the left out data. Not available if refit=False.
-
+    
     best_score_ : float
         Score of best_estimator on the left out data.
-
+    
     best_params_ : dict
         Parameter setting that gave the best results on the hold out data.
-
+    
+    best_index_ : int
+        The index (of the ``cv_results_`` arrays) which corresponds to the best
+        candidate parameter setting.
+        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
+        the parameter setting for the best model, that gives the highest
+        mean score (``search.best_score_``).
+    
     scorer_ : function
         Scorer function used on the held out data to choose the best
         parameters for the model.
+    
+    n_splits_ : int
+        The number of cross-validation splits (folds/iterations).
 
     Notes
     ------
@@ -249,7 +295,7 @@ class GridSearchCV(BaseSearchCV):
             local_y = y_bc.value
             res = fas(local_estimator, local_X, local_y, scorer, train, test, verbose,
                                   parameters, fit_params,
-                                  return_train_score=return_train_score, #was self.return_train_score (fixing this at true works??)
+                                  return_train_score=return_train_score,
                                   return_n_test_samples=True, return_times=True,
                                   return_parameters=False, error_score=error_score)
             return (index, res)
@@ -336,376 +382,3 @@ class GridSearchCV(BaseSearchCV):
                 best_estimator.fit(X, **fit_params)
             self.best_estimator_ = best_estimator
         return self
-
-    # def _get_param_iterator(self):
-    #     """Return ParameterGrid instance for the given param_grid"""
-    #     return ParameterGrid(self.param_grid)
-
-
-    # def fit(self, X, y=None, groups=None, **fit_params):
-    #         """Run fit with all sets of parameters.
-    #         Parameters
-    #         ----------
-    #         X : array-like, shape = [n_samples, n_features]
-    #             Training vector, where n_samples is the number of samples and
-    #             n_features is the number of features.
-    #         y : array-like, shape = [n_samples] or [n_samples, n_output], optional
-    #             Target relative to X for classification or regression;
-    #             None for unsupervised learning.
-    #         groups : array-like, with shape (n_samples,), optional
-    #             Group labels for the samples used while splitting the dataset into
-    #             train/test set.
-    #         **fit_params : dict of string -> object
-    #             Parameters passed to the ``fit`` method of the estimator
-    #         """
-    #         if self.fit_params is not None:
-    #             warnings.warn('"fit_params" as a constructor argument was '
-    #                           'deprecated in version 0.19 and will be removed '
-    #                           'in version 0.21. Pass fit parameters to the '
-    #                           '"fit" method instead.', DeprecationWarning)
-    #             if fit_params:
-    #                 warnings.warn('Ignoring fit_params passed as a constructor '
-    #                               'argument in favor of keyword arguments to '
-    #                               'the "fit" method.', RuntimeWarning)
-    #             else:
-    #                 fit_params = self.fit_params
-    #         estimator = self.estimator
-    #         cv = check_cv(self.cv, y, classifier=is_classifier(estimator))
-    #         self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
-
-    #         X, y, groups = indexable(X, y, groups)
-    #         n_splits = cv.get_n_splits(X, y, groups)
-    #         # Regenerate parameter iterable for each fit
-    #         candidate_params = list(self._get_param_iterator())
-    #         #candidate_params = ParameterGrid(self.param_grid)
-    #         n_candidates = len(candidate_params)
-    #         if self.verbose > 0:
-    #             print("Fitting {0} folds for each of {1} candidates, totalling"
-    #                   " {2} fits".format(n_splits, n_candidates,
-    #                                      n_candidates * n_splits))
-
-    #         base_estimator = clone(self.estimator)
-    #         pre_dispatch = self.pre_dispatch
-
-    #         out = Parallel(
-    #             n_jobs=self.n_jobs, verbose=self.verbose,
-    #             pre_dispatch=pre_dispatch
-    #         )(delayed(_fit_and_score)(clone(base_estimator), X, y, self.scorer_,
-    #                                   train, test, self.verbose, parameters,
-    #                                   fit_params=fit_params,
-    #                                   return_train_score=self.return_train_score,
-    #                                   return_n_test_samples=True,
-    #                                   return_times=True, return_parameters=False,
-    #                                   error_score=self.error_score)
-    #           for parameters, (train, test) in product(candidate_params,
-    #                                                    cv.split(X, y, groups)))
-
-    #         # if one choose to see train score, "out" will contain train score info
-    #         if self.return_train_score:
-    #             (train_scores, test_scores, test_sample_counts, fit_time,
-    #              score_time) = zip(*out)
-    #         else:
-    #             (test_scores, test_sample_counts, fit_time, score_time) = zip(*out)
-
-    #         results = dict()
-
-    #         def _store(key_name, array, weights=None, splits=False, rank=False):
-    #             """A small helper to store the scores/times to the cv_results_"""
-    #             # When iterated first by splits, then by parameters
-    #             array = np.array(array, dtype=np.float64).reshape(n_candidates,
-    #                                                               n_splits)
-    #             if splits:
-    #                 for split_i in range(n_splits):
-    #                     results["split%d_%s"
-    #                             % (split_i, key_name)] = array[:, split_i]
-
-    #             array_means = np.average(array, axis=1, weights=weights)
-    #             results['mean_%s' % key_name] = array_means
-    #             # Weighted std is not directly available in numpy
-    #             array_stds = np.sqrt(np.average((array -
-    #                                              array_means[:, np.newaxis]) ** 2,
-    #                                             axis=1, weights=weights))
-    #             results['std_%s' % key_name] = array_stds
-
-    #             if rank:
-    #                 results["rank_%s" % key_name] = np.asarray(
-    #                     rankdata(-array_means, method='min'), dtype=np.int32)
-
-    #         # Computed the (weighted) mean and std for test scores alone
-    #         # NOTE test_sample counts (weights) remain the same for all candidates
-    #         test_sample_counts = np.array(test_sample_counts[:n_splits],
-    #                                       dtype=np.int)
-
-    #         _store('test_score', test_scores, splits=True, rank=True,
-    #                weights=test_sample_counts if self.iid else None)
-    #         if self.return_train_score:
-    #             _store('train_score', train_scores, splits=True)
-    #         _store('fit_time', fit_time)
-    #         _store('score_time', score_time)
-
-    #         best_index = np.flatnonzero(results["rank_test_score"] == 1)[0]
-    #         best_parameters = candidate_params[best_index]
-
-    #         # Use one MaskedArray and mask all the places where the param is not
-    #         # applicable for that candidate. Use defaultdict as each candidate may
-    #         # not contain all the params
-    #         param_results = defaultdict(partial(MaskedArray,
-    #                                             np.empty(n_candidates,),
-    #                                             mask=True,
-    #                                             dtype=object))
-    #         for cand_i, params in enumerate(candidate_params):
-    #             for name, value in params.items():
-    #                 # An all masked empty array gets created for the key
-    #                 # `"param_%s" % name` at the first occurence of `name`.
-    #                 # Setting the value at an index also unmasks that index
-    #                 param_results["param_%s" % name][cand_i] = value
-
-    #         results.update(param_results)
-
-    #         # Store a list of param dicts at the key 'params'
-    #         results['params'] = candidate_params
-
-    #         self.cv_results_ = results
-    #         self.best_index_ = best_index
-    #         self.n_splits_ = n_splits
-
-    #         if self.refit:
-    #             # fit the best estimator using the entire dataset
-    #             # clone first to work around broken estimators
-    #             best_estimator = clone(base_estimator).set_params(
-    #                 **best_parameters)
-    #             if y is not None:
-    #                 best_estimator.fit(X, y, **fit_params)
-    #             else:
-    #                 best_estimator.fit(X, **fit_params)
-    #             self.best_estimator_ = best_estimator
-    #         return self
-
-
-
-
-    # def _fit_original(self, X, y, parameter_iterable):
-    #     """Actual fitting,  performing the search over parameters."""
-
-    #     estimator = self.estimator
-    #     cv = self.cv
-    #     self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
-
-    #     n_samples = _num_samples(X)
-    #     X, y = indexable(X, y)
-
-    #     if y is not None:
-    #         if len(y) != n_samples:
-    #             raise ValueError('Target variable (y) has a different number '
-    #                              'of samples (%i) than data (X: %i samples)'
-    #                              % (len(y), n_samples))
-    #     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
-    #     #cv = check_cv(cv, y, classifier=is_classifier(estimator))
-
-    #     if self.verbose > 0:
-    #         if isinstance(parameter_iterable, Sized):
-    #             n_candidates = len(parameter_iterable)
-    #             print("Fitting {0} folds for each of {1} candidates, totalling"
-    #                   " {2} fits".format(len(cv), n_candidates,
-    #                                      n_candidates * len(cv)))
-
-    #     base_estimator = clone(self.estimator)
-
-    #     param_grid = [(parameters, train, test)
-    #                   for parameters in parameter_iterable
-    #                   for (train, test) in cv]
-    #     # Because the original python code expects a certain order for the elements, we need to
-    #     # respect it.
-    #     indexed_param_grid = list(zip(range(len(param_grid)), param_grid))
-    #     par_param_grid = self.sc.parallelize(indexed_param_grid, len(indexed_param_grid))
-    #     X_bc = self.sc.broadcast(X)
-    #     y_bc = self.sc.broadcast(y)
-
-    #     scorer = self.scorer_
-    #     verbose = self.verbose
-    #     fit_params = self.fit_params
-    #     error_score = self.error_score
-    #     fas = _fit_and_score
-
-    #     def fun(tup):
-    #         (index, (parameters, train, test)) = tup
-    #         local_estimator = clone(base_estimator)
-    #         local_X = X_bc.value
-    #         local_y = y_bc.value
-    #         res = fas(local_estimator, local_X, local_y, scorer, train, test, verbose,
-    #                               parameters, fit_params,
-    #                               return_parameters=True, error_score=error_score)
-    #         return (index, res)
-    #     indexed_out0 = dict(par_param_grid.map(fun).collect())
-    #     out = [indexed_out0[idx] for idx in range(len(param_grid))]
-    #     # print "OUT:",out
-    #     # print "OUT[0]:",out[0]
-    #     # print "OUT[0].keys:",out[0].keys()
-    #     # sys.exit(0)
-    #     X_bc.unpersist()
-    #     y_bc.unpersist()
-
-    #     # Out is a list of triplet: score, estimator, n_test_samples
-    #     n_fits = len(out)
-    #     n_folds = len(cv)
-
-    #     scores = list()
-    #     grid_scores = list()
-    #     for grid_start in range(0, n_fits, n_folds):
-    #         n_test_samples = 0
-    #         score = 0
-    #         all_scores = []
-    #         for this_score, this_n_test_samples, _, parameters in \
-    #                 out[grid_start:grid_start + n_folds]:
-    #             all_scores.append(this_score)
-    #             if self.iid:
-    #                 this_score *= this_n_test_samples
-    #                 n_test_samples += this_n_test_samples
-    #             score += this_score
-    #         if self.iid:
-    #             score /= float(n_test_samples)
-    #         else:
-    #             score /= float(n_folds)
-    #         scores.append((score, parameters))
-    #         # TODO: shall we also store the test_fold_sizes?
-    #         grid_scores.append(_CVScoreTuple(
-    #             parameters,
-    #             score,
-    #             np.array(all_scores)))
-    #     # Store the computed scores
-    #     self.grid_scores_ = grid_scores
-
-    #     # Find the best parameters by comparing on the mean validation score:
-    #     # note that `sorted` is deterministic in the way it breaks ties
-    #     best = sorted(grid_scores, key=lambda x: x.mean_validation_score,
-    #                   reverse=True)[0]
-    #     self.best_params_ = best.parameters
-    #     self.best_score_ = best.mean_validation_score
-
-    #     if self.refit:
-    #         # fit the best estimator using the entire dataset
-    #         # clone first to work around broken estimators
-    #         best_estimator = clone(base_estimator).set_params(
-    #             **best.parameters)
-    #         if y is not None:
-    #             best_estimator.fit(X, y, **self.fit_params)
-    #         else:
-    #             best_estimator.fit(X, **self.fit_params)
-    #         self.best_estimator_ = best_estimator
-    #     return self
-
-
-
-
-
-    # def _fit_old(self, X, y, parameter_iterable):
-    #     """Actual fitting,  performing the search over parameters."""
-
-    #     estimator = self.estimator
-    #     cv = self.cv
-    #     self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
-
-    #     n_samples = _num_samples(X)
-    #     X, y = indexable(X, y)
-
-    #     if y is not None:
-    #         if len(y) != n_samples:
-    #             raise ValueError('Target variable (y) has a different number '
-    #                              'of samples (%i) than data (X: %i samples)'
-    #                              % (len(y), n_samples))
-    #     # cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
-    #     cv = check_cv(cv, y, classifier=is_classifier(estimator))
-
-    #     if self.verbose > 0:
-    #         if isinstance(parameter_iterable, Sized):
-    #             n_candidates = len(parameter_iterable)
-    #             print("Fitting {0} folds for each of {1} candidates, totalling"
-    #                   " {2} fits".format(len(cv), n_candidates,
-    #                                      n_candidates * len(cv)))
-
-    #     base_estimator = clone(self.estimator)
-
-    #     param_grid = [(parameters, train, test)
-    #                   for parameters in parameter_iterable
-    #                   for (train, test) in cv]
-    #     # Because the original python code expects a certain order for the elements, we need to
-    #     # respect it.
-    #     indexed_param_grid = list(zip(range(len(param_grid)), param_grid))
-    #     par_param_grid = self.sc.parallelize(indexed_param_grid, len(indexed_param_grid))
-    #     X_bc = self.sc.broadcast(X)
-    #     y_bc = self.sc.broadcast(y)
-
-    #     scorer = self.scorer_
-    #     verbose = self.verbose
-    #     fit_params = self.fit_params
-    #     error_score = self.error_score
-    #     fas = _fit_and_score
-
-    #     def fun(tup):
-    #         (index, (parameters, train, test)) = tup
-    #         local_estimator = clone(base_estimator)
-    #         local_X = X_bc.value
-    #         local_y = y_bc.value
-    #         res = fas(local_estimator, local_X, local_y, scorer, train, test, verbose,
-    #                               parameters, fit_params,
-    #                               return_train_score=self.return_train_score,
-    #                               return_n_test_samples=True, return_times=True,
-    #                               return_parameters=True, error_score=error_score)
-    #         return (index, res)
-    #     indexed_out0 = dict(par_param_grid.map(fun).collect())
-    #     out = [indexed_out0[idx] for idx in range(len(param_grid))]
-    #     print "OUT:",out
-    #     print "OUT[0]:",out[0]
-    #     print "OUT[0].keys:",out[0].keys()
-    #     sys.exit(0)
-    #     X_bc.unpersist()
-    #     y_bc.unpersist()
-
-    #     # Out is a list of triplet: score, estimator, n_test_samples
-    #     n_fits = len(out)
-    #     n_folds = len(cv)
-
-    #     scores = list()
-    #     grid_scores = list()
-    #     for grid_start in range(0, n_fits, n_folds):
-    #         n_test_samples = 0
-    #         score = 0
-    #         all_scores = []
-    #         for this_score, this_n_test_samples, _, parameters in \
-    #                 out[grid_start:grid_start + n_folds]:
-    #             all_scores.append(this_score)
-    #             if self.iid:
-    #                 this_score *= this_n_test_samples
-    #                 n_test_samples += this_n_test_samples
-    #             score += this_score
-    #         if self.iid:
-    #             score /= float(n_test_samples)
-    #         else:
-    #             score /= float(n_folds)
-    #         scores.append((score, parameters))
-    #         # TODO: shall we also store the test_fold_sizes?
-    #         grid_scores.append(_CVScoreTuple(
-    #             parameters,
-    #             score,
-    #             np.array(all_scores)))
-    #     # Store the computed scores
-    #     self.grid_scores_ = grid_scores
-
-    #     # Find the best parameters by comparing on the mean validation score:
-    #     # note that `sorted` is deterministic in the way it breaks ties
-    #     best = sorted(grid_scores, key=lambda x: x.mean_validation_score,
-    #                   reverse=True)[0]
-    #     self.best_params_ = best.parameters
-    #     self.best_score_ = best.mean_validation_score
-
-    #     if self.refit:
-    #         # fit the best estimator using the entire dataset
-    #         # clone first to work around broken estimators
-    #         best_estimator = clone(base_estimator).set_params(
-    #             **best.parameters)
-    #         if y is not None:
-    #             best_estimator.fit(X, y, **self.fit_params)
-    #         else:
-    #             best_estimator.fit(X, **self.fit_params)
-    #         self.best_estimator_ = best_estimator
-    #     return self

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -2,13 +2,23 @@
 Class for parallelizing GridSearchCV jobs in scikit-learn
 """
 
-from collections import Sized
+import sys
+
+from itertools import product
+from collections import Sized, Mapping, namedtuple, defaultdict, Sequence
+from functools import partial
 import numpy as np
+from scipy.stats import rankdata
 
 from sklearn.base import BaseEstimator, is_classifier, clone
-from sklearn.cross_validation import KFold, check_cv, _fit_and_score, _safe_split
-from sklearn.grid_search import BaseSearchCV, _check_param_grid, ParameterGrid, _CVScoreTuple
+#from sklearn.cross_validation import KFold, check_cv, _fit_and_score, _safe_split
+from sklearn.model_selection import KFold, check_cv, ParameterGrid # new
+from sklearn.model_selection._validation import _fit_and_score # new
+from sklearn.utils.metaestimators import _safe_split  # new
+#from sklearn.grid_search import BaseSearchCV, _check_param_grid, ParameterGrid, _CVScoreTuple
+from sklearn.model_selection._search import BaseSearchCV, _check_param_grid, _CVScoreTuple # new
 from sklearn.metrics.scorer import check_scoring
+from sklearn.utils.fixes import MaskedArray
 from sklearn.utils.validation import _num_samples, indexable
 
 class GridSearchCV(BaseSearchCV):
@@ -154,16 +164,20 @@ class GridSearchCV(BaseSearchCV):
 
     def __init__(self, sc, estimator, param_grid, scoring=None, fit_params=None,
                  n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
-                 pre_dispatch='2*n_jobs', error_score='raise'):
+                 pre_dispatch='2*n_jobs', error_score='raise', return_train_score=True):
         super(GridSearchCV, self).__init__(
             estimator, scoring, fit_params, n_jobs, iid,
-            refit, cv, verbose, pre_dispatch, error_score)
+            refit, cv, verbose, pre_dispatch, error_score, return_train_score)
+        # super(GridSearchCV, self).__init__(
+        #     estimator, scoring, fit_params, n_jobs, iid,
+        #     refit, cv, verbose, pre_dispatch, error_score)
         self.sc = sc
         self.param_grid = param_grid
-        self.grid_scores_ = None
+        # self.grid_scores_ = None
+        self.cv_results_ = None # new
         _check_param_grid(param_grid)
 
-    def fit(self, X, y=None):
+    def fit_old(self, X, y=None):
         """Run fit with all sets of parameters.
 
         Parameters
@@ -178,37 +192,36 @@ class GridSearchCV(BaseSearchCV):
             None for unsupervised learning.
 
         """
+        # print "Exiting"
+        # sys.exit(0)
         return self._fit(X, y, ParameterGrid(self.param_grid))
 
-    def _fit(self, X, y, parameter_iterable):
-        """Actual fitting,  performing the search over parameters."""
+    
 
+
+    #ef _fit(self, X, y, parameter_iterable, groups=None):
+    def fit(self, X, y=None, groups=None, **fit_params):
         estimator = self.estimator
-        cv = self.cv
+        cv = check_cv(self.cv, y, classifier=is_classifier(estimator))
         self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
 
-        n_samples = _num_samples(X)
-        X, y = indexable(X, y)
-
-        if y is not None:
-            if len(y) != n_samples:
-                raise ValueError('Target variable (y) has a different number '
-                                 'of samples (%i) than data (X: %i samples)'
-                                 % (len(y), n_samples))
-        cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
-
-        if self.verbose > 0:
-            if isinstance(parameter_iterable, Sized):
-                n_candidates = len(parameter_iterable)
-                print("Fitting {0} folds for each of {1} candidates, totalling"
-                      " {2} fits".format(len(cv), n_candidates,
-                                         n_candidates * len(cv)))
+        X, y, groups = indexable(X, y, groups)
+        n_splits = cv.get_n_splits(X, y, groups)
+        # Regenerate parameter iterable for each fit
+        #candidate_params = list(self._get_param_iterator())
+        #candidate_params = parameter_iterable # change later
+        candidate_params = ParameterGrid(self.param_grid)
+        n_candidates = len(candidate_params)
+        # if self.verbose > 0:
+        #     print("Fitting {0} folds for each of {1} candidates, totalling"
+        #           " {2} fits".format(n_splits, n_candidates,
+        #                              n_candidates * n_splits))
 
         base_estimator = clone(self.estimator)
 
-        param_grid = [(parameters, train, test)
-                      for parameters in parameter_iterable
-                      for (train, test) in cv]
+        param_grid = [(parameters, train, test) for parameters, (train, test) in product(candidate_params, cv.split(X, y, groups))]
+        #print "PARAM GRID:",param_grid,"\n"
+        #sys.exit(0)
         # Because the original python code expects a certain order for the elements, we need to
         # respect it.
         indexed_param_grid = list(zip(range(len(param_grid)), param_grid))
@@ -218,8 +231,9 @@ class GridSearchCV(BaseSearchCV):
 
         scorer = self.scorer_
         verbose = self.verbose
-        fit_params = self.fit_params
+        #fit_params = self.fit_params # DEPRECIATED: remove later
         error_score = self.error_score
+        return_train_score = self.return_train_score
         fas = _fit_and_score
 
         def fun(tup):
@@ -229,59 +243,352 @@ class GridSearchCV(BaseSearchCV):
             local_y = y_bc.value
             res = fas(local_estimator, local_X, local_y, scorer, train, test, verbose,
                                   parameters, fit_params,
-                                  return_parameters=True, error_score=error_score)
+                                  return_train_score=return_train_score, #was self.return_train_score (fixing this at true works??)
+                                  return_n_test_samples=True, return_times=True,
+                                  return_parameters=False, error_score=error_score)
             return (index, res)
         indexed_out0 = dict(par_param_grid.map(fun).collect())
+        #print "Indexed out:",indexed_out0,"\n"
         out = [indexed_out0[idx] for idx in range(len(param_grid))]
+        if return_train_score:
+            (train_scores, test_scores, test_sample_counts, fit_time,
+             score_time) = zip(*out)
+        else:
+            (test_scores, test_sample_counts, fit_time, score_time) = zip(*out)
+        #print "TRAIN SCORES:",train_scores
+        #print "SCORE TIME:",score_time
 
+        # print "OUT:",out,"\n"
+        # print "OUT[0]:",out[0]
+        # print "OUT[0].keys:",out[0].keys()
+        # sys.exit(0)
         X_bc.unpersist()
         y_bc.unpersist()
+        #print "GOT HERE?!?!?!? - shouldn't happen"
 
-        # Out is a list of triplet: score, estimator, n_test_samples
-        n_fits = len(out)
-        n_folds = len(cv)
 
-        scores = list()
-        grid_scores = list()
-        for grid_start in range(0, n_fits, n_folds):
-            n_test_samples = 0
-            score = 0
-            all_scores = []
-            for this_score, this_n_test_samples, _, parameters in \
-                    out[grid_start:grid_start + n_folds]:
-                all_scores.append(this_score)
-                if self.iid:
-                    this_score *= this_n_test_samples
-                    n_test_samples += this_n_test_samples
-                score += this_score
-            if self.iid:
-                score /= float(n_test_samples)
-            else:
-                score /= float(n_folds)
-            scores.append((score, parameters))
-            # TODO: shall we also store the test_fold_sizes?
-            grid_scores.append(_CVScoreTuple(
-                parameters,
-                score,
-                np.array(all_scores)))
-        # Store the computed scores
-        self.grid_scores_ = grid_scores
 
-        # Find the best parameters by comparing on the mean validation score:
-        # note that `sorted` is deterministic in the way it breaks ties
-        best = sorted(grid_scores, key=lambda x: x.mean_validation_score,
-                      reverse=True)[0]
-        self.best_params_ = best.parameters
-        self.best_score_ = best.mean_validation_score
+        # pre_dispatch = self.pre_dispatch
+
+        # out = Parallel(
+        #     n_jobs=self.n_jobs, verbose=self.verbose,
+        #     pre_dispatch=pre_dispatch
+        # )(delayed(_fit_and_score)(clone(base_estimator), X, y, self.scorer_,
+        #                           train, test, self.verbose, parameters,
+        #                           fit_params=fit_params,
+        #                           return_train_score=self.return_train_score,
+        #                           return_n_test_samples=True,
+        #                           return_times=True, return_parameters=False,
+        #                           error_score=self.error_score)
+        #   for parameters, (train, test) in product(candidate_params,
+        #                                            cv.split(X, y, groups)))
+
+        # # if one choose to see train score, "out" will contain train score info
+        # if self.return_train_score:
+        #     (train_scores, test_scores, test_sample_counts, fit_time,
+        #      score_time) = zip(*out)
+        # else:
+        #     (test_scores, test_sample_counts, fit_time, score_time) = zip(*out)
+
+        results = dict()
+
+        def _store(key_name, array, weights=None, splits=False, rank=False):
+            """A small helper to store the scores/times to the cv_results_"""
+            # When iterated first by splits, then by parameters
+            array = np.array(array, dtype=np.float64).reshape(n_candidates,
+                                                              n_splits)
+            if splits:
+                for split_i in range(n_splits):
+                    results["split%d_%s"
+                            % (split_i, key_name)] = array[:, split_i]
+
+            array_means = np.average(array, axis=1, weights=weights)
+            results['mean_%s' % key_name] = array_means
+            # Weighted std is not directly available in numpy
+            array_stds = np.sqrt(np.average((array -
+                                             array_means[:, np.newaxis]) ** 2,
+                                            axis=1, weights=weights))
+            results['std_%s' % key_name] = array_stds
+
+            if rank:
+                results["rank_%s" % key_name] = np.asarray(
+                    rankdata(-array_means, method='min'), dtype=np.int32)
+
+        # Computed the (weighted) mean and std for test scores alone
+        # NOTE test_sample counts (weights) remain the same for all candidates
+        test_sample_counts = np.array(test_sample_counts[:n_splits],
+                                      dtype=np.int)
+
+        _store('test_score', test_scores, splits=True, rank=True,
+               weights=test_sample_counts if self.iid else None)
+        if self.return_train_score:
+            _store('train_score', train_scores, splits=True)
+        _store('fit_time', fit_time)
+        _store('score_time', score_time)
+
+        best_index = np.flatnonzero(results["rank_test_score"] == 1)[0]
+        best_parameters = candidate_params[best_index]
+
+        # Use one MaskedArray and mask all the places where the param is not
+        # applicable for that candidate. Use defaultdict as each candidate may
+        # not contain all the params
+        param_results = defaultdict(partial(MaskedArray,
+                                            np.empty(n_candidates,),
+                                            mask=True,
+                                            dtype=object))
+        for cand_i, params in enumerate(candidate_params):
+            for name, value in params.items():
+                # An all masked empty array gets created for the key
+                # `"param_%s" % name` at the first occurence of `name`.
+                # Setting the value at an index also unmasks that index
+                param_results["param_%s" % name][cand_i] = value
+
+        results.update(param_results)
+
+        # Store a list of param dicts at the key 'params'
+        results['params'] = candidate_params
+
+        self.cv_results_ = results
+        self.best_index_ = best_index
+        self.n_splits_ = n_splits
 
         if self.refit:
             # fit the best estimator using the entire dataset
             # clone first to work around broken estimators
             best_estimator = clone(base_estimator).set_params(
-                **best.parameters)
+                **best_parameters)
             if y is not None:
-                best_estimator.fit(X, y, **self.fit_params)
+                best_estimator.fit(X, y, **fit_params)
             else:
-                best_estimator.fit(X, **self.fit_params)
+                best_estimator.fit(X, **fit_params)
             self.best_estimator_ = best_estimator
         return self
+
+
+
+
+    # def _fit_original(self, X, y, parameter_iterable):
+    #     """Actual fitting,  performing the search over parameters."""
+
+    #     estimator = self.estimator
+    #     cv = self.cv
+    #     self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
+
+    #     n_samples = _num_samples(X)
+    #     X, y = indexable(X, y)
+
+    #     if y is not None:
+    #         if len(y) != n_samples:
+    #             raise ValueError('Target variable (y) has a different number '
+    #                              'of samples (%i) than data (X: %i samples)'
+    #                              % (len(y), n_samples))
+    #     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
+    #     #cv = check_cv(cv, y, classifier=is_classifier(estimator))
+
+    #     if self.verbose > 0:
+    #         if isinstance(parameter_iterable, Sized):
+    #             n_candidates = len(parameter_iterable)
+    #             print("Fitting {0} folds for each of {1} candidates, totalling"
+    #                   " {2} fits".format(len(cv), n_candidates,
+    #                                      n_candidates * len(cv)))
+
+    #     base_estimator = clone(self.estimator)
+
+    #     param_grid = [(parameters, train, test)
+    #                   for parameters in parameter_iterable
+    #                   for (train, test) in cv]
+    #     # Because the original python code expects a certain order for the elements, we need to
+    #     # respect it.
+    #     indexed_param_grid = list(zip(range(len(param_grid)), param_grid))
+    #     par_param_grid = self.sc.parallelize(indexed_param_grid, len(indexed_param_grid))
+    #     X_bc = self.sc.broadcast(X)
+    #     y_bc = self.sc.broadcast(y)
+
+    #     scorer = self.scorer_
+    #     verbose = self.verbose
+    #     fit_params = self.fit_params
+    #     error_score = self.error_score
+    #     fas = _fit_and_score
+
+    #     def fun(tup):
+    #         (index, (parameters, train, test)) = tup
+    #         local_estimator = clone(base_estimator)
+    #         local_X = X_bc.value
+    #         local_y = y_bc.value
+    #         res = fas(local_estimator, local_X, local_y, scorer, train, test, verbose,
+    #                               parameters, fit_params,
+    #                               return_parameters=True, error_score=error_score)
+    #         return (index, res)
+    #     indexed_out0 = dict(par_param_grid.map(fun).collect())
+    #     out = [indexed_out0[idx] for idx in range(len(param_grid))]
+    #     # print "OUT:",out
+    #     # print "OUT[0]:",out[0]
+    #     # print "OUT[0].keys:",out[0].keys()
+    #     # sys.exit(0)
+    #     X_bc.unpersist()
+    #     y_bc.unpersist()
+
+    #     # Out is a list of triplet: score, estimator, n_test_samples
+    #     n_fits = len(out)
+    #     n_folds = len(cv)
+
+    #     scores = list()
+    #     grid_scores = list()
+    #     for grid_start in range(0, n_fits, n_folds):
+    #         n_test_samples = 0
+    #         score = 0
+    #         all_scores = []
+    #         for this_score, this_n_test_samples, _, parameters in \
+    #                 out[grid_start:grid_start + n_folds]:
+    #             all_scores.append(this_score)
+    #             if self.iid:
+    #                 this_score *= this_n_test_samples
+    #                 n_test_samples += this_n_test_samples
+    #             score += this_score
+    #         if self.iid:
+    #             score /= float(n_test_samples)
+    #         else:
+    #             score /= float(n_folds)
+    #         scores.append((score, parameters))
+    #         # TODO: shall we also store the test_fold_sizes?
+    #         grid_scores.append(_CVScoreTuple(
+    #             parameters,
+    #             score,
+    #             np.array(all_scores)))
+    #     # Store the computed scores
+    #     self.grid_scores_ = grid_scores
+
+    #     # Find the best parameters by comparing on the mean validation score:
+    #     # note that `sorted` is deterministic in the way it breaks ties
+    #     best = sorted(grid_scores, key=lambda x: x.mean_validation_score,
+    #                   reverse=True)[0]
+    #     self.best_params_ = best.parameters
+    #     self.best_score_ = best.mean_validation_score
+
+    #     if self.refit:
+    #         # fit the best estimator using the entire dataset
+    #         # clone first to work around broken estimators
+    #         best_estimator = clone(base_estimator).set_params(
+    #             **best.parameters)
+    #         if y is not None:
+    #             best_estimator.fit(X, y, **self.fit_params)
+    #         else:
+    #             best_estimator.fit(X, **self.fit_params)
+    #         self.best_estimator_ = best_estimator
+    #     return self
+
+
+
+
+
+    # def _fit_old(self, X, y, parameter_iterable):
+    #     """Actual fitting,  performing the search over parameters."""
+
+    #     estimator = self.estimator
+    #     cv = self.cv
+    #     self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
+
+    #     n_samples = _num_samples(X)
+    #     X, y = indexable(X, y)
+
+    #     if y is not None:
+    #         if len(y) != n_samples:
+    #             raise ValueError('Target variable (y) has a different number '
+    #                              'of samples (%i) than data (X: %i samples)'
+    #                              % (len(y), n_samples))
+    #     # cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
+    #     cv = check_cv(cv, y, classifier=is_classifier(estimator))
+
+    #     if self.verbose > 0:
+    #         if isinstance(parameter_iterable, Sized):
+    #             n_candidates = len(parameter_iterable)
+    #             print("Fitting {0} folds for each of {1} candidates, totalling"
+    #                   " {2} fits".format(len(cv), n_candidates,
+    #                                      n_candidates * len(cv)))
+
+    #     base_estimator = clone(self.estimator)
+
+    #     param_grid = [(parameters, train, test)
+    #                   for parameters in parameter_iterable
+    #                   for (train, test) in cv]
+    #     # Because the original python code expects a certain order for the elements, we need to
+    #     # respect it.
+    #     indexed_param_grid = list(zip(range(len(param_grid)), param_grid))
+    #     par_param_grid = self.sc.parallelize(indexed_param_grid, len(indexed_param_grid))
+    #     X_bc = self.sc.broadcast(X)
+    #     y_bc = self.sc.broadcast(y)
+
+    #     scorer = self.scorer_
+    #     verbose = self.verbose
+    #     fit_params = self.fit_params
+    #     error_score = self.error_score
+    #     fas = _fit_and_score
+
+    #     def fun(tup):
+    #         (index, (parameters, train, test)) = tup
+    #         local_estimator = clone(base_estimator)
+    #         local_X = X_bc.value
+    #         local_y = y_bc.value
+    #         res = fas(local_estimator, local_X, local_y, scorer, train, test, verbose,
+    #                               parameters, fit_params,
+    #                               return_train_score=self.return_train_score,
+    #                               return_n_test_samples=True, return_times=True,
+    #                               return_parameters=True, error_score=error_score)
+    #         return (index, res)
+    #     indexed_out0 = dict(par_param_grid.map(fun).collect())
+    #     out = [indexed_out0[idx] for idx in range(len(param_grid))]
+    #     print "OUT:",out
+    #     print "OUT[0]:",out[0]
+    #     print "OUT[0].keys:",out[0].keys()
+    #     sys.exit(0)
+    #     X_bc.unpersist()
+    #     y_bc.unpersist()
+
+    #     # Out is a list of triplet: score, estimator, n_test_samples
+    #     n_fits = len(out)
+    #     n_folds = len(cv)
+
+    #     scores = list()
+    #     grid_scores = list()
+    #     for grid_start in range(0, n_fits, n_folds):
+    #         n_test_samples = 0
+    #         score = 0
+    #         all_scores = []
+    #         for this_score, this_n_test_samples, _, parameters in \
+    #                 out[grid_start:grid_start + n_folds]:
+    #             all_scores.append(this_score)
+    #             if self.iid:
+    #                 this_score *= this_n_test_samples
+    #                 n_test_samples += this_n_test_samples
+    #             score += this_score
+    #         if self.iid:
+    #             score /= float(n_test_samples)
+    #         else:
+    #             score /= float(n_folds)
+    #         scores.append((score, parameters))
+    #         # TODO: shall we also store the test_fold_sizes?
+    #         grid_scores.append(_CVScoreTuple(
+    #             parameters,
+    #             score,
+    #             np.array(all_scores)))
+    #     # Store the computed scores
+    #     self.grid_scores_ = grid_scores
+
+    #     # Find the best parameters by comparing on the mean validation score:
+    #     # note that `sorted` is deterministic in the way it breaks ties
+    #     best = sorted(grid_scores, key=lambda x: x.mean_validation_score,
+    #                   reverse=True)[0]
+    #     self.best_params_ = best.parameters
+    #     self.best_score_ = best.mean_validation_score
+
+    #     if self.refit:
+    #         # fit the best estimator using the entire dataset
+    #         # clone first to work around broken estimators
+    #         best_estimator = clone(base_estimator).set_params(
+    #             **best.parameters)
+    #         if y is not None:
+    #             best_estimator.fit(X, y, **self.fit_params)
+    #         else:
+    #             best_estimator.fit(X, **self.fit_params)
+    #         self.best_estimator_ = best_estimator
+    #     return self

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -8,19 +8,18 @@ from itertools import product
 from collections import Sized, Mapping, namedtuple, defaultdict, Sequence
 from functools import partial
 import warnings
+
 import numpy as np
 from scipy.stats import rankdata
 
 from sklearn.base import BaseEstimator, is_classifier, clone
+from sklearn.metrics.scorer import check_scoring
 from sklearn.model_selection import KFold, check_cv, ParameterGrid
 from sklearn.model_selection._validation import _fit_and_score
-from sklearn.utils.metaestimators import _safe_split
 from sklearn.model_selection._search import BaseSearchCV, _check_param_grid, _CVScoreTuple
-from sklearn.metrics.scorer import check_scoring
 from sklearn.utils.fixes import MaskedArray
+from sklearn.utils.metaestimators import _safe_split
 from sklearn.utils.validation import _num_samples, indexable
-
-from sklearn.externals.joblib import Parallel, delayed
 
 
 class GridSearchCV(BaseSearchCV):

--- a/python/spark_sklearn/keyed_models.py
+++ b/python/spark_sklearn/keyed_models.py
@@ -320,7 +320,7 @@ class KeyedEstimator(pyspark.ml.Estimator):
         self._setDefault(**{paramName: paramSpec["default"]
                             for paramName, paramSpec in KeyedEstimator._paramSpecs.items()
                             if "default" in paramSpec})
-        kwargs = KeyedEstimator._inferredParams(sklearnEstimator, self.__init__._input_kwargs)
+        kwargs = KeyedEstimator._inferredParams(sklearnEstimator, self._input_kwargs)
         self._set(**kwargs)
 
         self._verifyEstimatorType()
@@ -489,7 +489,7 @@ class KeyedModel(pyspark.ml.Model):
         if yCol and type(outputType) not in KeyedModel._sql_types:
             raise TypeError("Output type {} is not an AtomicType (expected for {} estimator)"
                             .format(outputType, estimatorType))
-        self._set(**self.__init__._input_kwargs)
+        self._set(**self._input_kwargs)
 
     def _verifyEstimatorType(self):
         estimatorType = self.getOrDefault("estimatorType")

--- a/python/spark_sklearn/tests/test_gapply.py
+++ b/python/spark_sklearn/tests/test_gapply.py
@@ -85,10 +85,6 @@ class GapplyTests(RandomTest):
         dataGen = lambda: (random.randrange(GapplyTests.NVALS), random.randrange(GapplyTests.NVALS))
         self.checkGapplyEquivalentToPandas(pandasAggFunction, dataType, dataGen)
 
-    @unittest.skip("""
-    python only UDTs can't be nested in arraytypes for now, see SPARK-15989
-    this is only available starting in Spark 2.0.1
-    """)
     def test_gapply_python_only_udt_val(self):
         def pandasAggFunction(series):
             x = float(series.apply(lambda pt: int(pt.x) + int(pt.y)).sum())

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -32,6 +32,7 @@ _blacklist = set(['test_pickle',
                   'test_grid_search_precomputed_kernel_error_kernel_function',
                   'test_grid_search_precomputed_kernel',
                   'test_grid_search_failing_classifier_raise',
+                  'test_grid_search_score_method', # added this because the sklearn implementation of fit() fails it
                   'test_grid_search_failing_classifier']) # This one we should investigate
 
 def _create_method(method):

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -26,15 +26,6 @@ class SPGridSearchWrapper(GridSearchCV):
                                                 scoring, fit_params, n_jobs, iid, refit, cv,
                                                 verbose, pre_dispatch, error_score)
 
-    # These methods do not raise ValueError but something different
-_blacklist = set(['test_pickle',
-                  'test_grid_search_precomputed_kernel_error_nonsquare',
-                  'test_grid_search_precomputed_kernel_error_kernel_function',
-                  'test_grid_search_precomputed_kernel',
-                  'test_grid_search_failing_classifier_raise',
-                  'test_grid_search_score_method', # added this because the sklearn implementation of fit() fails it'
-                  'test_grid_search_failing_classifier']) # This one we should investigate
-
 def _create_method(method):
     def do_test_expected(*kwargs):
         method()
@@ -44,11 +35,9 @@ def _add_to_module():
     SKGridSearchCV = sklearn.grid_search.GridSearchCV
     sklearn.grid_search.GridSearchCV = SPGridSearchWrapper
     sklearn.grid_search.GridSearchCV_original = SKGridSearchCV
-    from sklearn.tests import test_grid_search
     from sklearn.model_selection.tests import test_search
-    allTests = test_grid_search.__dict__.items() + test_search.__dict__.items()
-    all_methods = [(mname, method) for (mname, method) in allTests
-                   if mname.startswith("test_") and mname not in _blacklist]
+    all_methods = [(mname, method) for (mname, method) in test_search.__dict__.items()
+                   if mname.startswith("test_")]
 
     for name, method in all_methods:
         method_for_test = _create_method(method)

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -32,7 +32,7 @@ _blacklist = set(['test_pickle',
                   'test_grid_search_precomputed_kernel_error_kernel_function',
                   'test_grid_search_precomputed_kernel',
                   'test_grid_search_failing_classifier_raise',
-                  'test_grid_search_score_method', # added this because the sklearn implementation of fit() fails it
+                  'test_grid_search_score_method', # added this because the sklearn implementation of fit() fails it'
                   'test_grid_search_failing_classifier']) # This one we should investigate
 
 def _create_method(method):

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -45,7 +45,9 @@ def _add_to_module():
     sklearn.grid_search.GridSearchCV = SPGridSearchWrapper
     sklearn.grid_search.GridSearchCV_original = SKGridSearchCV
     from sklearn.tests import test_grid_search
-    all_methods = [(mname, method) for (mname, method) in test_grid_search.__dict__.items()
+    from sklearn.model_selection.tests import test_search
+    allTests = test_grid_search.__dict__.items() + test_search.__dict__.items()
+    all_methods = [(mname, method) for (mname, method) in allTests
                    if mname.startswith("test_") and mname not in _blacklist]
 
     for name, method in all_methods:

--- a/python/spark_sklearn/tests/test_grid_search_2.py
+++ b/python/spark_sklearn/tests/test_grid_search_2.py
@@ -38,14 +38,9 @@ class CVTests2(MLlibTestCase):
         svr = svm.SVC()
         clf = grid_search.GridSearchCV(svr, parameters)
         clf.fit(iris.data, iris.target)
-        # clf = grid_search.GridSearchCV(svr)
-        # clf.fit(iris.data, iris.target, parameters)
-
 
         clf2 = GridSearchCV(self.sc, svr, parameters)
         clf2.fit(iris.data, iris.target)
-        # clf2 = GridSearchCV(self.sc, svr)
-        # clf2.fit(iris.data, iris.target, parameters)
 
         b1 = clf.estimator
         b2 = clf2.estimator
@@ -70,13 +65,7 @@ class CVTests(MLlibTestCase):
         X = scipy.sparse.vstack(map(lambda x: self.list2csr([x, x+1.0]), range(0, 100)))
         y = np.array(list(range(0, 100))).reshape((100,1))
         skl_gs = grid_search.fit(X, y)
-        #skl_gs = grid_search.fit(X, y, parameters)
-        #assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
-        #print "CV RESULTS KEYS:",skl_gs.cv_results_.keys()
         assert len(skl_gs.cv_results_['params']) == len(parameters['lasso__alpha'])
-        # TODO
-        # for gs in skl_gs.grid_scores_:
-        #     pass # assert(gs.)
 
     def test_cv_pipeline(self):
         pipeline = SKL_Pipeline([
@@ -101,12 +90,7 @@ class CVTests(MLlibTestCase):
                 ('too cool', 2.0)]
         df = self.sql.createDataFrame(data, ["review", "rating"]).toPandas()
         skl_gs = grid_search.fit(df.review.values, df.rating.values)
-        #skl_gs = grid_search.fit(df.review.values, df.rating.values, parameters)
-        #assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
         assert len(skl_gs.cv_results_['params']) == len(parameters['lasso__alpha'])
-        # TODO
-        # for gs in skl_gs.grid_scores_:
-        #     pass # assert(gs.)
 
     @unittest.skip("disable this test until we have numpy <-> dataframe conversion")
     def test_cv_lasso_with_mllib_featurization(self):
@@ -139,11 +123,4 @@ class CVTests(MLlibTestCase):
 
         grid_search = GridSearchCV(self.sc, pipeline, parameters)
         skl_gs = grid_search.fit(df.review.values, df.rating.values)
-        #grid_search = GridSearchCV(self.sc, pipeline)
-        #skl_gs = grid_search.fit(df.review.values, df.rating.values, parameters)
-
-        #assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
         assert len(skl_gs.cv_results_['params']) == len(parameters['lasso__alpha'])
-        # TODO
-        # for gs in skl_gs.grid_scores_:
-        #     pass

--- a/python/spark_sklearn/tests/test_grid_search_2.py
+++ b/python/spark_sklearn/tests/test_grid_search_2.py
@@ -38,9 +38,14 @@ class CVTests2(MLlibTestCase):
         svr = svm.SVC()
         clf = grid_search.GridSearchCV(svr, parameters)
         clf.fit(iris.data, iris.target)
+        # clf = grid_search.GridSearchCV(svr)
+        # clf.fit(iris.data, iris.target, parameters)
+
 
         clf2 = GridSearchCV(self.sc, svr, parameters)
         clf2.fit(iris.data, iris.target)
+        # clf2 = GridSearchCV(self.sc, svr)
+        # clf2.fit(iris.data, iris.target, parameters)
 
         b1 = clf.estimator
         b2 = clf2.estimator
@@ -61,13 +66,17 @@ class CVTests(MLlibTestCase):
             'lasso__alpha': (0.001, 0.005, 0.01)
         }
         grid_search = GridSearchCV(self.sc, pipeline, parameters)
+        #grid_search = GridSearchCV(self.sc, pipeline)
         X = scipy.sparse.vstack(map(lambda x: self.list2csr([x, x+1.0]), range(0, 100)))
         y = np.array(list(range(0, 100))).reshape((100,1))
         skl_gs = grid_search.fit(X, y)
-        assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
+        #skl_gs = grid_search.fit(X, y, parameters)
+        #assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
+        #print "CV RESULTS KEYS:",skl_gs.cv_results_.keys()
+        assert len(skl_gs.cv_results_['params']) == len(parameters['lasso__alpha'])
         # TODO
-        for gs in skl_gs.grid_scores_:
-            pass # assert(gs.)
+        # for gs in skl_gs.grid_scores_:
+        #     pass # assert(gs.)
 
     def test_cv_pipeline(self):
         pipeline = SKL_Pipeline([
@@ -79,6 +88,7 @@ class CVTests(MLlibTestCase):
             'lasso__alpha': (0.001, 0.005, 0.01)
         }
         grid_search = GridSearchCV(self.sc, pipeline, parameters)
+        #grid_search = GridSearchCV(self.sc, pipeline)
         data = [('hi there', 0.0),
                 ('what is up', 1.0),
                 ('huh', 1.0),
@@ -91,10 +101,12 @@ class CVTests(MLlibTestCase):
                 ('too cool', 2.0)]
         df = self.sql.createDataFrame(data, ["review", "rating"]).toPandas()
         skl_gs = grid_search.fit(df.review.values, df.rating.values)
-        assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
+        #skl_gs = grid_search.fit(df.review.values, df.rating.values, parameters)
+        #assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
+        assert len(skl_gs.cv_results_['params']) == len(parameters['lasso__alpha'])
         # TODO
-        for gs in skl_gs.grid_scores_:
-            pass # assert(gs.)
+        # for gs in skl_gs.grid_scores_:
+        #     pass # assert(gs.)
 
     @unittest.skip("disable this test until we have numpy <-> dataframe conversion")
     def test_cv_lasso_with_mllib_featurization(self):
@@ -127,8 +139,11 @@ class CVTests(MLlibTestCase):
 
         grid_search = GridSearchCV(self.sc, pipeline, parameters)
         skl_gs = grid_search.fit(df.review.values, df.rating.values)
+        #grid_search = GridSearchCV(self.sc, pipeline)
+        #skl_gs = grid_search.fit(df.review.values, df.rating.values, parameters)
 
-        assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
+        #assert len(skl_gs.grid_scores_) == len(parameters['lasso__alpha'])
+        assert len(skl_gs.cv_results_['params']) == len(parameters['lasso__alpha'])
         # TODO
-        for gs in skl_gs.grid_scores_:
-            pass
+        # for gs in skl_gs.grid_scores_:
+        #     pass

--- a/python/spark_sklearn/tests/test_grid_search_2.py
+++ b/python/spark_sklearn/tests/test_grid_search_2.py
@@ -61,7 +61,6 @@ class CVTests(MLlibTestCase):
             'lasso__alpha': (0.001, 0.005, 0.01)
         }
         grid_search = GridSearchCV(self.sc, pipeline, parameters)
-        #grid_search = GridSearchCV(self.sc, pipeline)
         X = scipy.sparse.vstack(map(lambda x: self.list2csr([x, x+1.0]), range(0, 100)))
         y = np.array(list(range(0, 100))).reshape((100,1))
         skl_gs = grid_search.fit(X, y)
@@ -77,7 +76,6 @@ class CVTests(MLlibTestCase):
             'lasso__alpha': (0.001, 0.005, 0.01)
         }
         grid_search = GridSearchCV(self.sc, pipeline, parameters)
-        #grid_search = GridSearchCV(self.sc, pipeline)
         data = [('hi there', 0.0),
                 ('what is up', 1.0),
                 ('huh', 1.0),


### PR DESCRIPTION
Currently, spark-sklearn gives deprecation warnings when used with sklearn version .18 because several classes in grid_search and cross_validation were refactored into a new module called model_selection. The changes here make spark-sklearn compatible with the changes introduced in sklearn .18. 

The most critical changes reflected in the new version of sklearn is that:

sklearn.model_selection.GridSearchCV now has:

cv_results_ : dict of numpy (masked) ndarrays - A dict with keys as column headers and values as columns, that can be imported into a pandas DataFrame.
best_estimator_ : estimator - Estimator that was chosen by the search, i.e. estimator which gave highest score (or smallest loss if specified) on the left out data. Not available if refit=False.
best_score_ : float - Score of best_estimator on the left out data.
best_params_ : dict - Parameter setting that gave the best results on the hold out data.
best_index_ : int - The index (of the cv_results_ arrays) which corresponds to the best candidate parameter setting.
scorer_ : function - Scorer function used on the held out data to choose the best parameters for the model.
n_splits_ : int - The number of cross-validation splits (folds/iterations).
While spark-sklearn.GridSearchCV has:

grid_scores_ : list of named tuples
best_estimator_ : estimator - Estimator that was chosen by the search, i.e. estimator which gave highest score (or smallest loss if specified) on the left out data. Not available if refit=False.
best_score_ : float - Score of best_estimator on the left out data.
best_params_ : dict - Parameter setting that gave the best results on the hold out data.
scorer_ : function - Scorer function used on the held out data to choose the best parameters for the model.
The biggest is that sklearn added the more comprehensive cv_results_ which adds data that the formerly compatible grid_scores_ is lacking.

Note: This version of spark-sklearn is not compatible with sklearn <= .17. 