### PR TITLE
[#63] Remove usage of deprecated scikit-learn API in GridSearchCV

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -65,7 +65,10 @@ More extensive documentation (generated with Sphinx) is available in the `python
 ## Changelog
 
 - 2015-12-10 First public release (0.1)
-- 2016-08-16 Minor release:
-   1. the official Spark target is Spark 0.2
+- 2016-08-16 Minor release (0.2.0):
+   1. the official Spark target is Spark 2.0
    2. support for keyed models
+- 2017-09-14 Minor release (0.2.2):
+   1. The official Spark target is Spark >= 2.1
+
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
 # This file should list any python package dependencies.
-scikit-learn>=0.18.1
+scikit-learn>=0.18.1, <=0.19

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
 # This file should list any python package dependencies.
-scikit-learn==0.18.1
+scikit-learn>=0.18.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
-INSTALL_REQUIRES = ["scikit-learn == 0.18.1"]
+INSTALL_REQUIRES = ["scikit-learn >= 0.18.1"]
 
 # Project root
 ROOT = os.path.abspath(os.getcwd() + "/")

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
-INSTALL_REQUIRES = ["scikit-learn >= 0.18.1"]
+INSTALL_REQUIRES = ["scikit-learn == 0.18.1"]
 
 # Project root
 ROOT = os.path.abspath(os.getcwd() + "/")

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
-INSTALL_REQUIRES = ["scikit-learn >= 0.18.1"]
+INSTALL_REQUIRES = ["scikit-learn >=0.18.1, <= 0.19"]
 
 # Project root
 ROOT = os.path.abspath(os.getcwd() + "/")

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -127,7 +127,7 @@ class GridSearchCV(BaseSearchCV):
                          kernel='rbf', max_iter=-1, probability=False,
                          random_state=None, shrinking=True, tol=...,
                          verbose=False),
-           fit_params=..., iid=..., n_jobs=1,
+           fit_params={}, iid=..., n_jobs=1,
            param_grid=..., pre_dispatch=..., refit=...,
            scoring=..., verbose=...)
     >>> sorted(clf.cv_results_.keys())

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -125,7 +125,7 @@ class GridSearchCV(BaseSearchCV):
                          kernel='rbf', max_iter=-1, probability=False,
                          random_state=None, shrinking=True, tol=...,
                          verbose=False),
-           fit_params={}, iid=..., n_jobs=1,
+           fit_params=..., iid=..., n_jobs=1,
            param_grid=..., pre_dispatch=..., refit=...,
            scoring=..., verbose=...)
     >>> sorted(clf.cv_results_.keys())
@@ -243,10 +243,7 @@ class GridSearchCV(BaseSearchCV):
             refit=refit, cv=cv, verbose=verbose, pre_dispatch=pre_dispatch, error_score=error_score,
             return_train_score=return_train_score)
 
-        if fit_params is None:
-            self.fit_params = {}
-        else:
-            self.fit_params = fit_params
+        self.fit_params = fit_params if fit_params is not None else {}
 
         self.sc = sc
         self.param_grid = param_grid

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -112,11 +112,13 @@ class GridSearchCV(BaseSearchCV):
     Examples
     --------
     >>> from sklearn import svm, datasets
-    >>> from sklearn.model_selection import GridSearchCV
+    >>> from spark_sklearn.grid_search import GridSearchCV
+    >>> from spark_sklearn.util import createLocalSparkSession
+    >>> sc = createLocalSparkSession().sparkContext
     >>> iris = datasets.load_iris()
     >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
     >>> svr = svm.SVC()
-    >>> clf = GridSearchCV(svr, parameters)
+    >>> clf = GridSearchCV(sc, svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     GridSearchCV(cv=None, error_score=...,

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -119,7 +119,7 @@ class GridSearchCV(BaseSearchCV):
     >>> clf = GridSearchCV(svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    SPGridSearchWrapper(cv=None, error_score=...,
+    GridSearchCV(cv=None, error_score=...,
            estimator=SVC(C=1.0, cache_size=..., class_weight=..., coef0=...,
                          decision_function_shape=..., degree=..., gamma=...,
                          kernel='rbf', max_iter=-1, probability=False,

--- a/python/spark_sklearn/grid_search.py
+++ b/python/spark_sklearn/grid_search.py
@@ -2,9 +2,6 @@
 Class for parallelizing GridSearchCV jobs in scikit-learn
 """
 
-import sys
-
-from itertools import product
 from collections import defaultdict, Sized
 from functools import partial
 import warnings
@@ -122,14 +119,14 @@ class GridSearchCV(BaseSearchCV):
     >>> clf = GridSearchCV(svr, parameters)
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    GridSearchCV(cv=None, error_score=...,
+    SPGridSearchWrapper(cv=None, error_score=...,
            estimator=SVC(C=1.0, cache_size=..., class_weight=..., coef0=...,
-                         decision_function_shape=None, degree=..., gamma=...,
+                         decision_function_shape=..., degree=..., gamma=...,
                          kernel='rbf', max_iter=-1, probability=False,
                          random_state=None, shrinking=True, tol=...,
                          verbose=False),
            fit_params={}, iid=..., n_jobs=1,
-           param_grid=..., pre_dispatch=..., refit=..., return_train_score=...,
+           param_grid=..., pre_dispatch=..., refit=...,
            scoring=..., verbose=...)
     >>> sorted(clf.cv_results_.keys())
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -242,9 +239,15 @@ class GridSearchCV(BaseSearchCV):
                  n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', error_score='raise', return_train_score=True):
         super(GridSearchCV, self).__init__(
-            estimator=estimator, scoring=scoring, fit_params=fit_params, n_jobs=n_jobs, iid=iid,
+            estimator=estimator, scoring=scoring, n_jobs=n_jobs, iid=iid,
             refit=refit, cv=cv, verbose=verbose, pre_dispatch=pre_dispatch, error_score=error_score,
             return_train_score=return_train_score)
+
+        if fit_params is None:
+            self.fit_params = {}
+        else:
+            self.fit_params = fit_params
+
         self.sc = sc
         self.param_grid = param_grid
 

--- a/python/spark_sklearn/tests/test_grid_search_1.py
+++ b/python/spark_sklearn/tests/test_grid_search_1.py
@@ -32,6 +32,10 @@ def _create_method(method):
     return do_test_expected
         
 def _add_to_module():
+    # NOTE: This doesn't actually run scikit-learn tests against SPGridSearchWrapper
+    # for scikit-learn >= 0.18, since the scikit-learn tests (in sklearn.model_selection.tests) use
+    # sklearn.model_selection.GridSearchCV (not sklearn.grid_search.GridSearchCV)
+    # TODO: Get scikit-learn tests to pass with spark-sklearn GridSearch implementation
     SKGridSearchCV = sklearn.grid_search.GridSearchCV
     sklearn.grid_search.GridSearchCV = SPGridSearchWrapper
     sklearn.grid_search.GridSearchCV_original = SKGridSearchCV


### PR DESCRIPTION
Update `spark_sklearn.model_selection.GridSearchCV` to pass `fit_params` to `fit()` rather than as a constructor argument to its superclass (`sklearn.model_selection.GridSearchCV`).

Also added a comment explaining that the tests in test_grid_search_1.py are currently skipped. These tests attempt to run scikit-learn `GridSearchCV` tests against the spark-sklearn implementation. Most of the scikit-learn tests pass, but tests that purposefully raise Exceptions (e.g. [test_grid_search_failing_classifier](https://github.com/scikit-learn/scikit-learn/blob/d9fdd8b0d1053cb47af8e3823b7a05279dd72054/sklearn/model_selection/tests/test_search.py#L1280)) fail since PySpark wraps the exceptions in Py4JErrors. PR #62 is a WIP attempt to fix the scikit-learn tests.