### PR TITLE
Bump version to 0.2.3, fix spark-package build

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ build the docs yourself, see the instructions in [docs/README.md](https://github
    2. support for keyed models
 - 2017-09-20 Minor release (0.2.2):
    1. The official Spark target is Spark >= 2.1
+- 2017-09-29 Minor release (0.2.3):
+   1. Fixes spark-package build of spark-sklearn.

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ sparkVersion := "2.1.1"
 spName := "databricks/spark-sklearn"
 
 // Don't forget to set the version
-version := "0.2.2"
+version := "0.2.3"
 
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,4 @@ include:
   - _modules
 
 # Specifies the current spark-sklearn version for the build
-SPARK_SKLEARN_VERSION: 0.2.2
+SPARK_SKLEARN_VERSION: 0.2.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 // You may use this file to add plugin dependencies for sbt.
 resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.2")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")

--- a/python/README.md
+++ b/python/README.md
@@ -70,5 +70,7 @@ More extensive documentation (generated with Sphinx) is available in the `python
    2. support for keyed models
 - 2017-09-20 Minor release (0.2.2):
    1. The official Spark target is Spark >= 2.1
+- 2017-09-29 Minor release (0.2.3):
+   1. Fixes spark-package build of spark-sklearn.
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
 	description="Integration tools for running scikit-learn on Spark",
 	license="Apache 2.0",
 	url="https://github.com/databricks/spark-sklearn",
-	version="0.2.2",
+	version="0.2.3",
 	author="Joseph Bradley",
 	author_email="joseph@databricks.com",
 	maintainer="Tim Hunter",


### PR DESCRIPTION
Upgraded `sbt-spark-package` plugin version so the spark-package JAR generated via `./build/sbt spDist` works properly. Bump version from 0.2.2 --> 0.2.3 so a new spark-package JAR can be released.

Verified that the spark-package JAR works by QAing on Databricks.