### PR TITLE
Fix Sampling Documentation In RandomSearchCV

### DIFF
--- a/python/spark_sklearn/random_search.py
+++ b/python/spark_sklearn/random_search.py
@@ -24,7 +24,7 @@ class RandomizedSearchCV(SparkBaseSearchCV):
 
     If all parameters are presented as a list,
     sampling without replacement is performed. If at least one parameter
-    is given as a distribution, sampling with replacement is used.
+    is given as a distribution, sampling with replacement is used for all parameters.
     It is highly recommended to use continuous distributions for continuous
     parameters.
 


### PR DESCRIPTION
One-liner clarifying what is sampled with replacement if a single param in param_distributions for RandomizedSearchCV is a distribution